### PR TITLE
Small tweaks, fixes ands improvements

### DIFF
--- a/spec/components/schemas/events/all.ts
+++ b/spec/components/schemas/events/all.ts
@@ -8,7 +8,6 @@ const all: SchemaObject = {
     $ref: messageEventRef,
   }, {
     $ref: messageStatusEventRef,
-  }, {
   }],
   discriminator: {
     propertyName: 'type',

--- a/spec/components/schemas/events/base.ts
+++ b/spec/components/schemas/events/base.ts
@@ -12,6 +12,7 @@ const eventBase: SchemaObject = {
     timestamp: {
       title: 'Event Timestamp',
       type: 'string',
+      format: 'date-time',
     },
     type: {
       title: 'Event type',

--- a/spec/components/schemas/message/all.ts
+++ b/spec/components/schemas/message/all.ts
@@ -4,9 +4,11 @@ import { ref as allContentsRef } from '../content/whatsapp/all';
 import { createComponentRef } from '../../../../utils/ref';
 
 const all: SchemaObject = {
+  type: 'object',
   allOf: [{
     $ref: baseRef,
   }, {
+    type: 'object',
     properties: {
       contents: {
         title: 'Message Contents',

--- a/spec/components/schemas/message/channel.ts
+++ b/spec/components/schemas/message/channel.ts
@@ -5,7 +5,6 @@ const base: SchemaObject = {
   type: 'string',
   title: 'Channel',
   description: 'Message channel',
-  readOnly: true,
 };
 
 export const ref = createComponentRef(__filename);

--- a/spec/components/schemas/message/facebook.ts
+++ b/spec/components/schemas/message/facebook.ts
@@ -4,9 +4,11 @@ import { ref as allContentsRef } from '../content/facebook/all';
 import { createComponentRef } from '../../../../utils/ref';
 
 const all: SchemaObject = {
+  type: 'object',
   allOf: [{
     $ref: baseRef,
   }, {
+    type: 'object',
     properties: {
       contents: {
         title: 'Message Contents',

--- a/spec/components/schemas/message/sms.ts
+++ b/spec/components/schemas/message/sms.ts
@@ -4,9 +4,11 @@ import { ref as allContentsRef } from '../content/sms/all';
 import { createComponentRef } from '../../../../utils/ref';
 
 const all: SchemaObject = {
+  type: 'object',
   allOf: [{
     $ref: baseRef,
   }, {
+    type: 'object',
     properties: {
       contents: {
         title: 'Message Contents',

--- a/spec/components/schemas/message/whatsapp.ts
+++ b/spec/components/schemas/message/whatsapp.ts
@@ -4,9 +4,11 @@ import { ref as allContentsRef } from '../content/whatsapp/all';
 import { createComponentRef } from '../../../../utils/ref';
 
 const all: SchemaObject = {
+  type: 'object',
   allOf: [{
     $ref: baseRef,
   }, {
+    type: 'object',
     properties: {
       contents: {
         title: 'Message Contents',

--- a/spec/components/schemas/status/message-status.ts
+++ b/spec/components/schemas/status/message-status.ts
@@ -7,6 +7,7 @@ const webhook: SchemaObject = {
     timestamp: {
       title: 'Status timestamp',
       type: 'string',
+      format: 'date-time',
     },
     code: {
       title: 'Status code',


### PR DESCRIPTION
As part of the work for replacing express-openapi-validate for openapi-enforcer+openapi-enforcer-middleware, small tweaks that the new validator said it was mandatory (mainly the "type" attribute), and removing a empty schema that it also complained about.

Plus adding format "date-time" to timestamp fields.

WIP because I might need to add more stuff to its complain about the subscription callback.