### PR TITLE
Criação do campo ContentIndex

### DIFF
--- a/spec/components/schemas/status/message-status.ts
+++ b/spec/components/schemas/status/message-status.ts
@@ -4,6 +4,10 @@ import { createComponentRef } from '../../../../utils/ref';
 const webhook: SchemaObject = {
   type: 'object',
   properties: {
+    contentIndex: {
+      title: 'Message Index',
+      type: 'number',
+    },
     timestamp: {
       title: 'Status timestamp',
       type: 'string',

--- a/spec/components/schemas/status/message-status.ts
+++ b/spec/components/schemas/status/message-status.ts
@@ -5,7 +5,7 @@ const webhook: SchemaObject = {
   type: 'object',
   properties: {
     contentIndex: {
-      title: 'Message Index',
+      title: 'Index of content that is receiving the status update',
       type: 'number',
     },
     timestamp: {

--- a/spec/tags/subscriptions.md
+++ b/spec/tags/subscriptions.md
@@ -47,6 +47,7 @@ If you are subscribed in this type of event, your webhook will receive a request
   "channel": "string",
   "messageId": "string",
   "messageStatus": {
+    "contentIndex": "number",
     "timestamp": "string",
     "code": "string",
     "description": "string",


### PR DESCRIPTION
Atualmente, as atualizações de status não informam qual o conteúdo que está recebendo a atualização quando a mensagem disparada possuí mais de um conteúdo. Estamos implantando a correção deste comportamento em nossa plataforma e, portanto, estou adicionando o campo contentIndex na documentação do callback do MessageStatus para que seja possível a identificação.