### PR TITLE
Added documentation for Templates endpoint

### DIFF
--- a/bin/commons.ts
+++ b/bin/commons.ts
@@ -28,7 +28,13 @@ export function generateReDocPage(): string {
       ${redocExport}.init(
         './openapi.json',
         ${JSON.stringify(redocConfig)},
-        document.getElementById("redoc_container")
+        document.getElementById("redoc_container"),
+        function () {
+          var els = document.querySelectorAll('td');
+          for (el of els) {
+            el.click();
+          }
+        }
       );
     </script>`);
   return pageContents;

--- a/redoc/redoc-config.yaml
+++ b/redoc/redoc-config.yaml
@@ -7,3 +7,5 @@ theme:
     medium: '800px'
 pathInMiddlePanel: false
 noAutoAuth: true
+jsonSampleExpandLevel: all
+expandResponses: '200'

--- a/spec/components/parameters/templateId.ts
+++ b/spec/components/parameters/templateId.ts
@@ -1,0 +1,15 @@
+import { ParameterObject } from 'openapi3-ts';
+import { createComponentRef } from '../../../utils/ref';
+
+const templateId: ParameterObject = {
+  name: 'templateId',
+  in: 'path',
+  required: true,
+  description: 'the template identifier',
+  schema: {
+    type: 'string',
+  },
+};
+
+export const ref = createComponentRef(__filename);
+export default templateId;

--- a/spec/components/schemas/templates/base.ts
+++ b/spec/components/schemas/templates/base.ts
@@ -1,0 +1,73 @@
+// tslint:disable:max-line-length
+import { SchemaObject } from 'openapi3-ts';
+import { createComponentRef } from '../../../../utils/ref';
+import { ref as statusRef } from './status';
+
+const base: SchemaObject = {
+  title: 'Template Object',
+  description: 'This is a Template object model.',
+  type: 'object',
+  properties: {
+    id: {
+      title: 'Template ID',
+      type: 'string',
+      readOnly: true,
+    },
+    text: {
+      title: 'Template text',
+      description: 'The text message of this template',
+      type: 'string',
+    },
+    fields: {
+      title: 'Fields',
+      description: 'The available fields to be used in this template.',
+      type: 'array',
+      items: {
+        type: 'string',
+      },
+      minItems: 0,
+    },
+    channels: {
+      title: 'Channels',
+      description: 'Channels where this template can be used',
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          type: {
+            title: 'Template type',
+            type: 'string',
+            enum: [
+              'WHATSAPP',
+              'FACEBOOK',
+              'SMS',
+            ],
+          },
+          senderId: {
+            title: 'Sender ID',
+            type: 'string',
+          },
+          status: {
+            $ref: statusRef,
+          },
+        },
+      },
+      minItems: 1,
+    },
+    createdAt: {
+      title: 'Creation timestamp',
+      description: 'Creation timestamp in ISO format',
+      type: 'string',
+      readOnly: true,
+    },
+    updatedAt: {
+      title: 'Update timestamp',
+      description: 'Update timestamp in ISO format',
+      type: 'string',
+      readOnly: true,
+    },
+  },
+};
+
+export const ref = createComponentRef(__filename);
+export default base;

--- a/spec/components/schemas/templates/status.ts
+++ b/spec/components/schemas/templates/status.ts
@@ -1,0 +1,17 @@
+// tslint:disable:max-line-length
+import { SchemaObject } from 'openapi3-ts';
+import { createComponentRef } from '../../../../utils/ref';
+
+const status: SchemaObject = {
+  title: 'Status of template',
+  type: 'string',
+  enum: [
+    'APPROVED',
+    'REFUSED',
+    'PENDING',
+    'CANCELED',
+  ],
+};
+
+export const ref = createComponentRef(__filename);
+export default status;

--- a/spec/info/description.md
+++ b/spec/info/description.md
@@ -105,6 +105,7 @@ Responses error codes are detailed below.
 | 400              | VALIDATION_ERROR     | Validation error                 | No            |
 | 401              | AUTHENTICATION_ERROR | No authorization token was found | No            |
 | 404              | NOT_FOUND            | Not found                        | No            |
+| 409              | DUPLICATED           | Entity already exists            | No            |
 | 500              | INTERNAL_ERROR       | Internal error                   | Yes           |
 
 # Authentication

--- a/spec/paths/templates/templates.ts
+++ b/spec/paths/templates/templates.ts
@@ -1,0 +1,38 @@
+import {
+  PathItemObject,
+  OperationObject,
+  SchemaObject,
+  ResponseObject,
+  ResponsesObject,
+} from 'openapi3-ts';
+import { ref as templateSchemaRef } from '../../components/schemas/templates/base';
+import { ref as errorResponseRef } from '../../components/responses/error';
+
+const get: OperationObject = {
+  description: 'List all templates',
+  tags: ['Templates'],
+  responses: {
+    200: {
+      description: 'Template Object List',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'array',
+            items: {
+              $ref: templateSchemaRef,
+            },
+          } as SchemaObject,
+        },
+      },
+    } as ResponseObject,
+    default: {
+      $ref: errorResponseRef,
+    },
+  } as ResponsesObject,
+};
+
+const path: PathItemObject = {
+  get,
+};
+
+export default path;

--- a/spec/paths/templates/templates@{templateId}.ts
+++ b/spec/paths/templates/templates@{templateId}.ts
@@ -1,0 +1,33 @@
+import { PathItemObject, OperationObject, ResponsesObject, ResponseObject } from 'openapi3-ts';
+import { ref as templateSchemaRef } from '../../components/schemas/templates/base';
+import { ref as templateIdRef } from '../../components/parameters/templateId';
+import { ref as errorResponseRef } from '../../components/responses/error';
+
+const getOperation: OperationObject = {
+  description: 'Retrieve one template by id',
+  tags: ['Templates'],
+  responses: {
+    200: {
+      description: 'Template Object',
+      content: {
+        'application/json': {
+          schema: {
+            $ref: templateSchemaRef,
+          },
+        },
+      },
+    } as ResponseObject,
+    default: {
+      $ref: errorResponseRef,
+    },
+  } as ResponsesObject,
+};
+
+const path: PathItemObject = {
+  get: getOperation,
+  parameters: [{
+    $ref: templateIdRef,
+  }],
+};
+
+export default path;

--- a/spec/tags/groups.ts
+++ b/spec/tags/groups.ts
@@ -12,6 +12,11 @@ const groups: TagGroupObject[] = [{
   tags: [
     'Subscriptions',
   ],
+}, {
+  name: 'Templates',
+  tags: [
+    'Templates',
+  ],
 }];
 
 export default groups;

--- a/spec/tags/index.ts
+++ b/spec/tags/index.ts
@@ -4,6 +4,7 @@ import { rawLoad } from '../../utils/raw-load';
 const whatsappDescription = rawLoad(__dirname, './whatsapp.md');
 const facebookDescription = rawLoad(__dirname, './facebook.md');
 const subscriptionsDescription = rawLoad(__dirname, './subscriptions.md');
+const templatesDescription = rawLoad(__dirname, './templates.md');
 
 const tags: TagObject[] = [{
   name: 'WhatsApp',
@@ -14,6 +15,9 @@ const tags: TagObject[] = [{
 }, {
   name: 'Subscriptions',
   description: subscriptionsDescription,
+}, {
+  name: 'Templates',
+  description: templatesDescription,
 }];
 
 export default tags;

--- a/spec/tags/templates.md
+++ b/spec/tags/templates.md
@@ -1,0 +1,3 @@
+Message Templates are message formats for common reusable messages a business may want to send. Businesses must use Message Templates for sending notifications to customers.
+
+This allows a business to send just the template identifier along with the appropriate parameters instead of the full message content.


### PR DESCRIPTION
Adding templates endpoint to the API documentation. This PR contains only `GET /templates` and `GET /templates/{some-id}` endpoints that will be release first. The others operations in templates, such as create, update and delete, will be launch in near future.

Also, as requested, it was changed to all collapsed variable in request and response schemas be initialized as expanded.