### PR TITLE
Updated example of Message Status

### DIFF
--- a/spec/tags/subscriptions.md
+++ b/spec/tags/subscriptions.md
@@ -51,7 +51,13 @@ If you are subscribed in this type of event, your webhook will receive a request
     "timestamp": "string",
     "code": "string",
     "description": "string",
-    "cause": "string"
+    "causes": [
+      {
+        "channelErrorCode": "number or string",
+        "reason": "string",
+        "details": "string"
+      }
+    ],
   }
 }
 ```


### PR DESCRIPTION
Updated example of Message Status payload replacing 'cause' to 'causes' field.