### PR TITLE
Added status DEGRADED to subscription status enum

### DIFF
--- a/spec/components/schemas/subscription/status.ts
+++ b/spec/components/schemas/subscription/status.ts
@@ -7,6 +7,7 @@ const status: SchemaObject = {
   type: 'string',
   enum: [
     'ACTIVE',
+    'DEGRADED',
     'INACTIVE',
   ],
 };


### PR DESCRIPTION
Due to refactoring on subscription health in API Subscription Control, the new status DEGRADED must be added to subscription status enum.