### PR TITLE
Including visitor on payload of message.

### DIFF
--- a/spec/components/schemas/message/all.ts
+++ b/spec/components/schemas/message/all.ts
@@ -2,6 +2,7 @@ import { SchemaObject } from 'openapi3-ts';
 import { ref as baseRef } from './base';
 import { ref as allContentsRef } from '../content/whatsapp/all';
 import { createComponentRef } from '../../../../utils/ref';
+import { ref as visitorSchemaRef } from './visitor';
 
 const all: SchemaObject = {
   type: 'object',
@@ -10,6 +11,9 @@ const all: SchemaObject = {
   }, {
     type: 'object',
     properties: {
+      visitor: {
+        $ref: visitorSchemaRef,
+      },
       contents: {
         title: 'Message Contents',
         description: 'A list of content to be sent',

--- a/spec/components/schemas/message/base.ts
+++ b/spec/components/schemas/message/base.ts
@@ -25,7 +25,7 @@ const base: SchemaObject = {
     },
     direction: {
       title: 'Message direction',
-      description: 'Indicate if message is received from channel (IN) or is sent to channel (OUT)',
+      description: 'It indicates if message is received from channel (IN) or is sent to channel (OUT)',
       type: 'string',
       enum: [
         'IN',

--- a/spec/components/schemas/message/visitor.ts
+++ b/spec/components/schemas/message/visitor.ts
@@ -2,18 +2,23 @@ import { SchemaObject } from 'openapi3-ts';
 import { createComponentRef } from '../../../../utils/ref';
 
 const visitor: SchemaObject = {
+  title: 'Visitor Object',
+  description: 'Indicate the name of the visitor who sent the message',
   type: 'object',
   properties: {
     name: {
       title: 'Name',
+      description: 'Full name of the visitor',
       type: 'string',
     },
     firstName: {
       title: 'First name',
+      description: 'First name of the visitor',
       type: 'string',
     },
     lastName: {
       title: 'Last name',
+      description: 'Last name of the visitor',
       type: 'string',
     },
   },

--- a/spec/components/schemas/message/visitor.ts
+++ b/spec/components/schemas/message/visitor.ts
@@ -3,7 +3,7 @@ import { createComponentRef } from '../../../../utils/ref';
 
 const visitor: SchemaObject = {
   title: 'Visitor Object',
-  description: 'Indicate the name of the visitor who sent the message',
+  description: 'It indicates the name of the visitor who sent the message',
   type: 'object',
   properties: {
     name: {

--- a/spec/components/schemas/message/visitor.ts
+++ b/spec/components/schemas/message/visitor.ts
@@ -1,0 +1,23 @@
+import { SchemaObject } from 'openapi3-ts';
+import { createComponentRef } from '../../../../utils/ref';
+
+const visitor: SchemaObject = {
+  type: 'object',
+  properties: {
+    name: {
+      title: 'Name',
+      type: 'string',
+    },
+    firstName: {
+      title: 'First name',
+      type: 'string',
+    },
+    lastName: {
+      title: 'Last name',
+      type: 'string',
+    },
+  },
+};
+
+export const ref = createComponentRef(__filename);
+export default visitor;

--- a/spec/components/schemas/subscription/message-subscription.ts
+++ b/spec/components/schemas/subscription/message-subscription.ts
@@ -19,7 +19,7 @@ const subscription: SchemaObject = {
           },
           direction: {
             title: 'Message direction',
-            description: 'Indicate if message is received from channel (IN) or is sent to channel (OUT)',
+            description: 'It indicates if message is received from channel (IN) or is sent to channel (OUT)',
             type: 'string',
             enum: [
               'IN',

--- a/spec/tags/subscriptions.md
+++ b/spec/tags/subscriptions.md
@@ -20,6 +20,11 @@ When you are subscribed in this type of event, your webhook will receive a reque
     "to": "string",
     "direction": "string",
     "channel": "string",
+    "visitor": {
+      "name": "string",
+      "firstName": "string",
+      "lastName": "string"
+    },
     "contents": [
       {
         "type": "string",


### PR DESCRIPTION
Nesta task, quando receber um evento do tipo **MESSAGE** com o payload visitor dentro do contents, a aplicação irá duplicar este dado de forma que crie na raiz um novo atributo do tipo objeto chamado “**VISITOR**”.