### PR TITLE
Adicionar video no header dos templates - v1

### DIFF
--- a/spec/components/schemas/templates/components/header/index.ts
+++ b/spec/components/schemas/templates/components/header/index.ts
@@ -5,7 +5,7 @@ export const header: SchemaObject = {
   title: 'Header',
   description: 'Template header',
   type: 'object',
-  required: ['type', 'text'],
+  required: ['type'],
   properties: {
     type: {
       title: 'Header type',

--- a/spec/components/schemas/templates/components/header/index.ts
+++ b/spec/components/schemas/templates/components/header/index.ts
@@ -11,7 +11,7 @@ export const header: SchemaObject = {
       title: 'Header type',
       description: 'The header can have an image, document or text.',
       type: 'string',
-      enum: ['MEDIA_DOCUMENT', 'MEDIA_IMAGE', 'TEXT_FIXED', 'TEXT_TEMPLATE'],
+      enum: ['MEDIA_DOCUMENT', 'MEDIA_IMAGE', 'MEDIA_VIDEO', 'TEXT_FIXED', 'TEXT_TEMPLATE'],
     },
     text: {
       title: 'Header text',


### PR DESCRIPTION
Pessoal,

Adicionei apenas o `MEDIA_VIDEO` no `enums` dos types permitidos no header dos templates.