### PR TITLE
SMS doc link v2

### DIFF
--- a/spec/tags/facebook.md
+++ b/spec/tags/facebook.md
@@ -1,4 +1,4 @@
-The Facebook channel can be used after that you add Facebook Pages on Zenvia platform.
+The Facebook channel may be used after you connect a Facebook Page on [Zenvia platform](https://app.zenvia.com/home/credentials).
 
 ## Facebook sender and recipient
 

--- a/spec/tags/sms.md
+++ b/spec/tags/sms.md
@@ -1,7 +1,14 @@
 The SMS channel may be used after its activation on [Zenvia platform](https://app.zenvia.com/home/credentials).
 
-## SMS sender and recipient
+## ZenAPI vs SMS API
+This API allows you to use other channels beyond SMS.
 
+However, if you are interested in just the SMS channel, or you need a feature still
+unavailable on this API, you may want to use the previous [SMS API](https://zenviasmsenus.docs.apiary.io/#).
+
+The SMS API is officially supported, but it *might* be discontinued one day.
+
+## SMS sender and recipient
 When you send some message for one contact using SMS channel:
 
 * Recipient: is the phone number of contact

--- a/spec/tags/sms.md
+++ b/spec/tags/sms.md
@@ -1,12 +1,11 @@
 The SMS channel may be used after its activation on [Zenvia platform](https://app.zenvia.com/home/credentials).
 
 ## ZenAPI vs SMS API
-This API allows you to use other channels beyond SMS.
+ZenAPI allows you to use multiple channels. However, if you are interested in just
+the SMS channel, you may access the old API, which for now, have more
+SMS features.
 
-However, if you are interested in just the SMS channel, or you need a feature still
-unavailable on this API, you may want to use the previous [SMS API](https://zenviasmsenus.docs.apiary.io/#).
-
-The SMS API is officially supported, but it *might* be discontinued one day.
+For more information about it, visit: [SMS API documentation](https://zenviasmsenus.docs.apiary.io/#).
 
 ## SMS sender and recipient
 When you send some message for one contact using SMS channel:

--- a/spec/tags/sms.md
+++ b/spec/tags/sms.md
@@ -1,4 +1,4 @@
-The SMS channel can be used after your activation on Zenvia platform.
+The SMS channel may be used after its activation on [Zenvia platform](https://app.zenvia.com/home/credentials).
 
 ## SMS sender and recipient
 

--- a/spec/tags/whatsapp.md
+++ b/spec/tags/whatsapp.md
@@ -1,6 +1,6 @@
-The WhatsApp channel can be used after your activation on Zenvia platform.
+The WhatsApp channel may be used after its activation on Zenvia platform.
 
-To activate WhatsApp you a need a registered number on WhatsApp Business API and account informations configured on Zenvia platform.
+To activate WhatsApp you a need a registered number on WhatsApp Business API and account information configured on Zenvia platform.
 
 **Get in touch with Zenvia consultants to start your account creation.**
 


### PR DESCRIPTION
Updated text to match the request, just did a few small changes.


No longer applied:

Adding SMS documentation link as requested, but I changed the text originally sent:
![Screenshot_2020-07-27 ZenAPI API Reference](https://user-images.githubusercontent.com/4666758/88604981-11ed9c80-d04f-11ea-908f-8b6fae400e82.png)

Original text:
The ZenAPI
will allow you to use our multiple channels, but if you are interest just in
the SMS resource, you can have access to the API old version, that have more
features for now, but that will be discontinued soon. For more information
about our API SMS, visit: https://zenviasms.docs.apiary.io/#reference/servicos-da-api

@carloshenriqueds O que você acha sobre esse texto? Eu provavelmente vou mergear isso hoje e depois alteramos pra melhorar. Tentei ficar no meio termo entre incentivar o uso da nova API sem descartar a anterior.