### PR TITLE
Putting "version" back and a few tweaks

### DIFF
--- a/spec/tags/sms.md
+++ b/spec/tags/sms.md
@@ -1,11 +1,13 @@
 The SMS channel may be used after its activation on [Zenvia platform](https://app.zenvia.com/home/credentials).
+<br/><br/>
 
-## ZenAPI vs SMS API
+### ZenAPI vs SMS API
 ZenAPI allows you to use multiple channels. However, if you are interested in just
-the SMS channel, you may access the old API, which for now, have more
+the SMS channel, you may access the old API version, which for now have more
 SMS features.
 
-For more information about it, visit: [SMS API documentation](https://zenviasmsenus.docs.apiary.io/#).
+For more information about our [SMS API](https://zenviasmsenus.docs.apiary.io/#),
+visit its [documentation](https://zenviasmsenus.docs.apiary.io/#).
 
 ## SMS sender and recipient
 When you send some message for one contact using SMS channel:


### PR DESCRIPTION
Update for: https://github.com/zenvia/zenvia-openapi-spec/pull/38

Updated request:
*The ZenAPI will allow you to use our multiple channels, but if you are interest just in
the SMS resource, you can have access to the API old version, that have more
features for now. 
For more information about our API SMS, visit: https://zenviasms.docs.apiary.io/#reference/servicos-da-api*

I tweaked the text a bit (replaced a few adverbs, articles and verb tenses) and the final result:
![image](https://user-images.githubusercontent.com/4666758/89063490-aa7d6880-d33e-11ea-852e-a7ac688282d1.png)

~~Adding SMS documentation link as requested, but I changed the text originally sent:
![Screenshot_2020-07-27 ZenAPI API Reference](https://user-images.githubusercontent.com/4666758/88604981-11ed9c80-d04f-11ea-908f-8b6fae400e82.png)~~