### PR TITLE
Adding SMS specific text attributes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
 script:
   - npm run lint
   - npm test
-  - npm run build
+  - npm run build:public
 deploy:
   provider: script
   skip_cleanup: true

--- a/README.md
+++ b/README.md
@@ -47,6 +47,17 @@ npm run build
 npm test
 ```
 
+**4.** Starts the development server (with the public version of the specification).
+
+```shell
+npm run start:public
+```
+
+**5.** Bundles the spec (with the public version of the specification) and prepares web_deploy folder with static assets.
+
+```shell
+npm run build:public
+```
 
 
 ## License

--- a/package.json
+++ b/package.json
@@ -5,11 +5,13 @@
   "main": "spec/index.js",
   "scripts": {
     "start": "ts-node-dev --no-deps --respawn --files ./bin/serve.ts",
+    "start:public": "PUBLIC=true ts-node-dev --no-deps --respawn --files ./bin/serve.ts",
     "lint": "tslint --project tsconfig.json --config tslint.json 'spec/**/*.ts' 'bin/**/*.ts' 'utils/**/*.ts'",
     "validate": "ts-node --files ./bin/validate.ts",
     "test-unit": "mocha",
     "test": "npm run validate && npm run test-unit",
-    "build": "ts-node --files ./bin/build.ts"
+    "build": "ts-node --files ./bin/build.ts",
+    "build:public": "PUBLIC=true ts-node --files ./bin/build.ts"
   },
   "author": "Henrique Magarotto <henrique.magarotto@zenvia.com> (https://github.com/hmagarotto)",
   "contributors": [

--- a/spec/components/schemas/content/sms/all.ts
+++ b/spec/components/schemas/content/sms/all.ts
@@ -1,5 +1,5 @@
 import { SchemaObject } from 'openapi3-ts';
-import { ref as textRef } from '../text';
+import { ref as textRef } from './text';
 import { createComponentRef } from '../../../../../utils/ref';
 
 const all: SchemaObject = {

--- a/spec/components/schemas/content/sms/text.ts
+++ b/spec/components/schemas/content/sms/text.ts
@@ -1,0 +1,57 @@
+import { SchemaObject } from 'openapi3-ts';
+import { ref as textRef } from '../text';
+import { createComponentRef } from '../../../../../utils/ref';
+
+const text: SchemaObject = {
+  type: 'object',
+  allOf: [{
+    $ref: textRef,
+  }, {
+    type: 'object',
+    properties: {
+      encodingStrategy: {
+        type: 'string',
+        enum: [
+          'AUTO',
+          'MORE_CHARACTER_SUPPORT',
+          'MORE_CHARACTER_PER_MESSAGE',
+        ],
+        default: 'AUTO',
+        writeOnly: true,
+        title: 'write only',
+        description: `The method used for selecting the message encoding used to dispatch the message to the provider.
+          <br>The default value **AUTO** will select the encoding method based on the text content, so this is only necessary
+          if you need to enforce **MORE_CHARACTER_PER_MESSAGE** method (not recommended), or to enforce **MORE_CHARACTER_SUPPORT**
+          if you have any trouble with **AUTO**.
+          <br>*Only applicable to [SMS channel](#tag/SMS).*`,
+        example: 'AUTO',
+      },
+      reportId: {
+        'x-unpublished': true,
+        deprecated: true,
+        type: 'number',
+        writeOnly: true,
+        title: 'write only',
+        description: `An id used for report purposes only (also known as aggregate id). It must be setup before use.
+          <br>*Only applicable to [SMS channel](#tag/SMS).*`,
+        example: 12345,
+        minimum: -2147483648,
+        maximum: 2147483647,
+      },
+      popUpOnScreen: {
+        'x-unpublished': true,
+        deprecated: true,
+        type: 'boolean',
+        default: false,
+        writeOnly: true,
+        title: 'write only',
+        description: `When **true**, the message will pop up on screen (also known as flash message).
+          <br>*Only applicable to [SMS channel](#tag/SMS).*`,
+        example: 'true',
+      },
+    },
+  }],
+};
+
+export const ref = createComponentRef(__filename);
+export default text;

--- a/spec/components/schemas/content/sms/text.ts
+++ b/spec/components/schemas/content/sms/text.ts
@@ -14,7 +14,7 @@ const text: SchemaObject = {
         enum: [
           'AUTO',
           'MORE_CHARACTER_SUPPORT',
-          'MORE_CHARACTER_PER_MESSAGE',
+          'MORE_CHARACTERS_PER_MESSAGE',
         ],
         default: 'AUTO',
         writeOnly: true,

--- a/spec/components/schemas/content/text.ts
+++ b/spec/components/schemas/content/text.ts
@@ -24,41 +24,6 @@ const text: SchemaObject = {
         readOnly: true,
         title: 'read only',
       },
-      popUpOnScreen: {
-        type: 'boolean',
-        default: false,
-        writeOnly: true,
-        title: 'write only',
-        description: `When **true**, the message will pop up on screen (also known as flash message).
-          <br>*Only applicable to [SMS channel](#tag/SMS).*`,
-        example: 'true',
-      },
-      encodingMethod: {
-        type: 'string',
-        enum: [
-          'AUTO',
-          'UNICODE',
-          'ASCII',
-        ],
-        default: 'AUTO',
-        writeOnly: true,
-        title: 'write only',
-        description: `The method used for selecting the message encoding used to dispatch the message to the provider.
-          <br>The default value **AUTO** will select the encoding method based on the text content, so this is only necessary
-          if you need to enforce **ASCII** method (not recommended), or to enforce **UNICODE** if you have any trouble with **AUTO**.
-          <br>*Only applicable to [SMS channel](#tag/SMS).*`,
-        example: 'AUTO',
-      },
-      reportId: {
-        type: 'number',
-        writeOnly: true,
-        title: 'write only',
-        description: `An id used for report purposes only (also known as aggregate id).
-          <br>*Only applicable to [SMS channel](#tag/SMS).*`,
-        example: 12345,
-        minimum: -2147483648,
-        maximum: 2147483647,
-      },
     },
     required: [
       'type',

--- a/spec/components/schemas/content/text.ts
+++ b/spec/components/schemas/content/text.ts
@@ -54,7 +54,7 @@ const text: SchemaObject = {
         type: 'number',
         writeOnly: true,
         title: 'write only',
-        description: `An id used for report purpose only (also known as aggregate id).
+        description: `An id used for report purposes only (also known as aggregate id).
           <br>*Only applicable to [SMS channel](#tag/SMS).*`,
         example: 12345,
         minimum: -2147483648,

--- a/spec/components/schemas/content/text.ts
+++ b/spec/components/schemas/content/text.ts
@@ -16,12 +16,49 @@ const text: SchemaObject = {
       text: {
         description: 'Text to be sent',
         type: 'string',
-        example: 'This is a text',
+        example: 'This is a text.',
       },
       payload: {
         description: 'Payload of selected button.',
         type: 'string',
         readOnly: true,
+        title: 'read only',
+      },
+      popUpOnScreen: {
+        type: 'boolean',
+        default: false,
+        writeOnly: true,
+        title: 'write only',
+        description: `When **true**, the message will pop up on screen (also known as flash message).
+          <br>*Only applicable to [SMS channel](#tag/SMS).*`,
+        example: 'true',
+      },
+      encodingMethod: {
+        name: 'encodingMethod',
+        type: 'string',
+        enum: [
+          'AUTO',
+          'UNICODE',
+          'ASCII',
+        ],
+        default: 'AUTO',
+        writeOnly: true,
+        title: 'write only',
+        description: `The method used for selecting the message encoding used to dispatch the message to the provider.
+          <br>The default value **AUTO** will select the encoding method based on the text content, so this is only necessary
+          if you need to enforce **ASCII** method (not recommended), or to enforce **UNICODE** if you have any trouble with **AUTO**.
+          <br>*Only applicable to [SMS channel](#tag/SMS).*`,
+        example: 'AUTO',
+      },
+      reportId: {
+        type: 'number',
+        writeOnly: true,
+        title: 'write only',
+        description: `An id used for report purpose only (also known as aggregate id).
+          <br>*Only applicable to [SMS channel](#tag/SMS).*`,
+        example: 12345,
+        minimum: -2147483648,
+        maximum: 2147483647,
       },
     },
     required: [

--- a/spec/components/schemas/content/text.ts
+++ b/spec/components/schemas/content/text.ts
@@ -34,7 +34,6 @@ const text: SchemaObject = {
         example: 'true',
       },
       encodingMethod: {
-        name: 'encodingMethod',
         type: 'string',
         enum: [
           'AUTO',

--- a/spec/components/schemas/message/base.ts
+++ b/spec/components/schemas/message/base.ts
@@ -15,12 +15,15 @@ const base: SchemaObject = {
     },
     from: {
       title: 'Sender ID',
-      description: 'This is the identifier of sender of this message. The sender shoud be created with a credential.',
+      description: `This is the identifier of sender of this message. The sender is created when an integration for the channel is connected
+        on the [integrations console](https://app.zenvia.com/home/credentials).
+        <br>More details on the channel\'s *sender and recipient* section.`,
       type: 'string',
     },
     to: {
       title: 'Recipient ID',
-      description: 'The recipient is the identifier of a contact in this channel.',
+      description: `The identifier of the contact (varies according to the channel) who will receive the message.
+        <br>More details on the channel\'s *sender and recipient* section.`,
       type: 'string',
     },
     direction: {

--- a/spec/components/schemas/message/sms.ts
+++ b/spec/components/schemas/message/sms.ts
@@ -11,13 +11,9 @@ const all: SchemaObject = {
     type: 'object',
     properties: {
       contents: {
-        title: 'Message Contents',
-        description: 'A list of content to be sent',
-        type: 'array',
         items: {
           $ref: allContentsRef,
         },
-        minItems: 1,
       },
     },
   }],

--- a/spec/components/schemas/message/sms.ts
+++ b/spec/components/schemas/message/sms.ts
@@ -11,9 +11,13 @@ const all: SchemaObject = {
     type: 'object',
     properties: {
       contents: {
+        title: 'Message Contents',
+        description: 'A list of content to be sent',
+        type: 'array',
         items: {
           $ref: allContentsRef,
         },
+        minItems: 1,
       },
     },
   }],

--- a/spec/tags/content-types.md
+++ b/spec/tags/content-types.md
@@ -13,7 +13,7 @@ Messaging can be handled through SMS, WhatsApp, Facebook and RCS channels. For e
 ## Text
 This type of content is the most used type of content, and its composed of a plain text.
 
-<SchemaDefinition schemaRef="#/components/schemas/content.text" />
+<SchemaDefinition schemaRef="#/components/schemas/content.text" showWriteOnly="true" />
 
 ## File
 This is used to send a file to the user. The file will be presented to the user in different manner based on the file type. There are four types of presentation:

--- a/spec/tags/content-types.md
+++ b/spec/tags/content-types.md
@@ -22,22 +22,22 @@ This is used to send a file to the user. The file will be presented to the user 
 * Audio
 * Document
 
-<SchemaDefinition schemaRef="#/components/schemas/content.file" />
+<SchemaDefinition schemaRef="#/components/schemas/content.file" showWriteOnly="true" />
 
 ## Contacts
 Use this type of content to send contacts information to the user.
 
-<SchemaDefinition schemaRef="#/components/schemas/content.contacts" />
+<SchemaDefinition schemaRef="#/components/schemas/content.contacts" showWriteOnly="true" />
 
 ## Location
 This content is used to send location messages representing a point on the map to the user.
 
-<SchemaDefinition schemaRef="#/components/schemas/content.location" />
+<SchemaDefinition schemaRef="#/components/schemas/content.location" showWriteOnly="true" />
 
 ## Template
 Template contents have a fixed text content, with a few variables placed where necessary. This type of content must be submitted for approval to WhatsApp. The nature of the content that is subjected to approval is very limited.
 
-<SchemaDefinition schemaRef="#/components/schemas/content.template" />
+<SchemaDefinition schemaRef="#/components/schemas/content.template" showWriteOnly="true" />
 
 ### Submitting a template content for approval
 If you already have a WhatsApp business account with us, just send email to *whatsapp@zenvia.com* and we will start the process for you.

--- a/spec/tags/facebook.md
+++ b/spec/tags/facebook.md
@@ -12,4 +12,4 @@ When you receive a message from one contact, the sender and recipient is inverte
 * Recipient: is your page id
 * Sender: is the user id on your page (PSID - page scoped id)
 
-In API the sender is the field `from` and the receiver is the field `to` of message object.
+The sender goes in the attribute `from` and the receiver goes in the attribute `to` of message object.

--- a/spec/tags/rcs.md
+++ b/spec/tags/rcs.md
@@ -19,4 +19,4 @@ When you receive a message from one contact, the sender and recipient is inverte
 Recipient: is the RCS Agent ID
 Sender: is the phone number of contact
 
-In API the sender is the field from and the receiver is the field to of message object.
+The sender goes in the attribute `from` and the receiver goes in the attribute `to` of message object.

--- a/spec/tags/sms.md
+++ b/spec/tags/sms.md
@@ -14,4 +14,4 @@ When you receive a message from one contact, the sender and recipient is inverte
 * Recipient: is the SMS account alias connected on [integrations console](https://app.zenvia.com/home/credentials).
 * Sender: is the complete phone number (including country code) of contact.
 
-In API the sender is the field `from` and the receiver is the field `to` of message object.
+The sender goes in the attribute `from` and the receiver goes in the attribute `to` of message object.

--- a/spec/tags/sms.md
+++ b/spec/tags/sms.md
@@ -1,23 +1,15 @@
 The SMS channel may be used after its activation on [Zenvia platform](https://app.zenvia.com/home/credentials).
 <br/><br/>
 
-### ZenAPI vs SMS API
-ZenAPI allows you to use multiple channels. However, if you are interested in just
-the SMS channel, you may access the old API version, which for now have more
-SMS features.
-
-For more information about our [SMS API](https://zenviasmsenus.docs.apiary.io/#),
-visit its [documentation](https://zenviasmsenus.docs.apiary.io/#).
-
 ## SMS sender and recipient
-When you send some message for one contact using SMS channel:
+When you send a message for one contact using SMS channel:
 
-* Recipient: is the phone number of contact
-* Sender: is the SMS sender id
+* Recipient: is the complete phone number (including country code) of contact.
+* Sender: is the SMS account alias connected on [integrations console](https://app.zenvia.com/home/credentials).
 
 When you receive a message from one contact, the sender and recipient is inverted:
 
-* Recipient: is the SMS sender id
-* Sender: is the phone number of contact
+* Recipient: is the SMS account alias connected on [integrations console](https://app.zenvia.com/home/credentials).
+* Sender: is the complete phone number (including country code) of contact.
 
 In API the sender is the field `from` and the receiver is the field `to` of message object.

--- a/spec/tags/whatsapp.md
+++ b/spec/tags/whatsapp.md
@@ -36,4 +36,4 @@ When you receive a message from one contact, the sender and recipient is inverte
 * Recipient: is the WhatsApp sender id configured on [Zenvia platform](https://app.zenvia.com/home/credentials/whatsapp/list)
 * Sender: is the phone number of contact
 
-In API the sender is the field `from` and the receiver is the field `to` of message object.
+The sender goes in the attribute `from` and the receiver goes in the attribute `to` of message object.

--- a/utils/openapi-extensions.d.ts
+++ b/utils/openapi-extensions.d.ts
@@ -1,4 +1,4 @@
-import { ExampleObject, BaseParameterObject } from 'openapi3-ts';
+import {} from 'openapi3-ts';
 
 declare module 'openapi3-ts' {
   export interface TagGroupObject {
@@ -12,6 +12,9 @@ declare module 'openapi3-ts' {
     lang: string;
     label?: string;
     source: string;
+  }
+  export interface SchemaObject {
+    'x-unpublished'?: boolean;
   }
   /*
   export interface OpenAPIObject  extends ISpecificationExtension {


### PR DESCRIPTION
UPDATE:

Conforme conversas e alinhamentos internos:
- **reportId** (aggregateId): na plataforma CPaaS ele não existe. Não faz sentido mesmo ter. Deixando ele disponível pra uso em caso de alguma necessidade específica, mas não incluindo ele na especificação oficial.
- **popUpOnScreen** (flashSms): as operadoras estão bloqueando esse tipo de mensagem, então deixando mais por já estar deixando o aggregateId.
- **encoding~~Method~~Strategy** (dataCoding): conforme alinhamento, ficará documentado na API mesmo tendo sido criado o valor *AUTO*.

Contudo, optei por criar um conteúdo texto específico pra SMS, então essas propriedades só existem em SMS. Isso significa que na seção *Content Types* essa propriedade (encodingStrategy) não será exibida.

Mensagem SMS:
![image](https://user-images.githubusercontent.com/4666758/99811197-9777e980-2b23-11eb-8b12-0cadf84dfc8e.png)

"ORIGINAL":
Conforme cartão https://redmine.zenvia360.com/issues/39826 adicionando suporte a 3 campos específicos da API REST de SMS:
dataCoding, flashSms e aggregateId.

Consideração prévia que fiz:
- Por serem coisas bem específicas de SMS fiquei na dúvida se realmente deveria ter colocado diretamente no content Text, em especial o aggregateId que só serve pra relatório e é bem específico da API SMS, por isso cheguei a considerar um campo à parte de content pra dados mais específicos de canal/API, mas como o conteúdo de texto ia ser o único com isso, e como já há campos suportados só por alguns canais (fileCaption por exemplo em mídia), acabei deixando no content Text.

Agora considerações por atributo:
- **flashSms**
  - Pra tentar deixar algo mais genérico que potencialmente possa ser usado por outros canais, optei por chamar de  **popUpOnScreen**.
  - Nos testes que eu fiz no meu celular que é Android e é Claro não teve efeito esse atributo.
    - Ele funciona mesmo?
    - Requer alguma configuração na conta?
- **dataCoding**
  - Nome e valores muito específicos de APIs SMS, fora que podemos abstrair essa decisão de qual codificação usar pros usuários não terem que se preocupar com isso.
  - Também não acho que precisamos especificar claramente qual charset está sendo usado, e sim meio que a "estratégia" que está sendo usada pra selecionar o charset.
    - Então optei por chamar de **encoding~~Method~~Strategy**, com três opções de valores:
      - **AUTO**: valor padrão que acredito atender a todos os cenários o que potecialmente torna esse atributo irrelevante, o que pode significar que talvez não precisamos realmente expor esse atributo e sempre usar esse comportamento por trás dos panos.
        - Eu testei todos os caracteres do charset GSM-7 e mais alguns ASCII e ISO-8859-1 que estão fora dele, e alguns que só tem em unicode, e cheguei em uma lista de caracteres que são suportados pela API REST no *dataCoding 0*: **\\[]{}^~-@£$\r¥Øø\nÅå_Ææß !"#¤%&()*+,-./0123456789:;<=>?¡ABCDEFGHIJKLMNOPQRSTUVWXYZÑ§¿abcdefghijklmnopqrstuvwxyzñ**
        - Então a lógica do valor **AUTO** seria a seguinte: o texto só tem esses caracteres? *dataCoding 0*, caso contrário, *dataCoding 8*. Planejo implementar essa lógica no connector-sms.
      - **~~UNICODE~~MORE_CHARACTER_SUPPORT**: seria o equivalente ao *dataCoding 8* (que envia pro celular usando UCS-2).
      - **~~ASCII~~MORE_CHARACTERS_PER_MESSAGE**: seria o equivalente ao *dataCoding 0* (que envia pro celular usando GSM-7). Não sei se *ASCII* ficou um bom nome pois na real suporta um pouco mais de caracteres que o charset *ASCII* suporta, e ao mesmo tempo não suporta todos os caracteres dele. Talvez renomeie se pensar num nome melhor que indique algo bem limitado kkkk
- **aggregateId**
  - Esse é o que eu até agora me debato se realmente deveria estar aqui ou mesmo se realmente deveríamos suportá-lo!
     - É somente pra relatório/fatuaramento, nada relacionado com o conteúdo em si, e ainda é numérico somente, uma limitação bem específica da API REST. Contudo, por enquanto, tá mapeado aqui.
  - Optei por renomeá-lo na API para **reportId** na tentativa de indicar que é algo usado só pra relatórios (tipo um metadado).

Documentação do conteúdo Text atualizada:
![image](https://user-images.githubusercontent.com/4666758/98750969-f314db00-239d-11eb-9847-d7ce67098670.png)

~~PS: Acho que quebrei os testes, terei que atualizá-los ainda.~~
