### PR TITLE
Renaming from messageIdRef to idRef, according with the tested payload

### DIFF
--- a/spec/components/schemas/message/all.ts
+++ b/spec/components/schemas/message/all.ts
@@ -23,7 +23,7 @@ const all: SchemaObject = {
         },
         minItems: 1,
       },
-      messageIdRef: {
+      idRef: {
         title: 'read only',
         description: 'When an user sends a message quoting a previous message, the idetifier of the quoted message will be provided here.<br>*Only applicable to [WhatsApp channel](#tag/WhatsApp).*',
         type: 'string',


### PR DESCRIPTION
@rafaelgpimenta identificou pelo payload de teste que o atributo recebido é idRef, e não messageIdRef.