### PR TITLE
Change zenvia favicon and logo

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,9 +3,7 @@
 <head>
   <title>ZenAPI | API Reference</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon32x32.png">
-  <link rel="icon" type="image/png" sizes="192x192" href="assets/favicon192x192.png">
-  <link rel="apple-touch-icon-precomposed" type="image/png" href="assets/favicon.png">
+  <link rel="icon" type="image/x-icon" href="https://zenvia-static.s3.amazonaws.com/favicon.ico">
   <meta http-equiv="refresh" content="0; URL='./v2'"/>
 </head>
 <body>

--- a/redoc/template.html
+++ b/redoc/template.html
@@ -17,9 +17,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <!-- favicon -->
-    <link rel="icon" type="image/png" sizes="32x32" href="../assets/favicon32x32.png">
-    <link rel="icon" type="image/png" sizes="192x192" href="../assets/favicon192x192.png">
-    <link rel="apple-touch-icon-precomposed" type="image/png" href="../assets/favicon.png">
+    <link rel="icon" type="image/x-icon" href="https://zenvia-static.s3.amazonaws.com/favicon.ico">
 
     <!--
     ReDoc uses font options from the parent element

--- a/spec/info/index.ts
+++ b/spec/info/index.ts
@@ -18,7 +18,7 @@ const info: InfoObject = {
     url:  'https://raw.githubusercontent.com/zenvia/zenvia-openapi-spec/master/LICENSE.md',
   },
   'x-logo': {
-    url: 'https://zenvia.github.io/zenvia-openapi-spec/assets/zenapi.png',
+    url: 'https://zenvia-static.s3.amazonaws.com/brand/zenvia-brand-mark-regular.svg',
   },
 };
 


### PR DESCRIPTION
Change favicon and logo to use a S3 URI.

**Before:**

![zenapi-brand-before](https://user-images.githubusercontent.com/3268876/113366204-e7b35380-932e-11eb-92d2-c6e3d706e2e5.png)

**After:**

![zenapi-brand-after](https://user-images.githubusercontent.com/3268876/113366216-eda93480-932e-11eb-9305-2c3861e04b6c.png)

