### PR TITLE
Integrations links and tweaks

### DIFF
--- a/spec/tags/facebook.md
+++ b/spec/tags/facebook.md
@@ -1,15 +1,21 @@
-The Facebook channel may be used after you connect a Facebook Page on [Zenvia platform](https://app.zenvia.com/home/credentials).
+The Facebook channel may be used after you connect a Facebook Page on [Zenvia platform](https://app.zenvia.com/home/credentials/facebook/list).
+
+
+## Limitations
+
+To be able to send messages to a contact, you first need to setup a webhook, which allow you to receive events in the configured URL. [Learn more here](#tag/Webhooks).
+
 
 ## Facebook sender and recipient
 
-When you send some message for one contact using Facebook channel:
-
-* Recipient: is the user id on your page (PSID - page scoped id)
-* Sender: is your page id
-
-When you receive a message from one contact, the sender and recipient are inverted:
+When you receive a message from a contact from Facebook channel:
 
 * Recipient: is your page id
-* Sender: is the user id on your page (PSID - page scoped id)
+* Sender: is the contact id on your page (PSID - page scoped id)
+
+When you send some message to a contact, the sender and recipient are inverted:
+
+* Recipient: is the contact id on your page (PSID - page scoped id)
+* Sender: is your page id
 
 The sender goes in the attribute `from` and the receiver goes in the attribute `to` of message object.

--- a/spec/tags/facebook.md
+++ b/spec/tags/facebook.md
@@ -3,7 +3,7 @@ The Facebook channel may be used after you connect a Facebook Page on [Zenvia pl
 
 ## Limitations
 
-To be able to send messages to a contact, you first need to setup a webhook, which allow you to receive events in the configured URL. [Learn more here](#tag/Webhooks).
+To be able to send messages to a contact, you first need to setup a webhook, which allows you to receive events in the configured URL. [Learn more here](#tag/Webhooks).
 
 
 ## Facebook sender and recipient

--- a/spec/tags/gbm.md
+++ b/spec/tags/gbm.md
@@ -7,7 +7,7 @@ To activate Google Business Message you need to be registered as a partner with 
 
 ## Limitations
 
-To be able to send messages to a contact, you first need to setup a webhook, which allow you to receive events in the configured URL. [Learn more here](#tag/Webhooks).
+To be able to send messages to a contact, you first need to setup a webhook, which allows you to receive events in the configured URL. [Learn more here](#tag/Webhooks).
 
 
 ## Google Business Message sender and recipient

--- a/spec/tags/gbm.md
+++ b/spec/tags/gbm.md
@@ -4,18 +4,19 @@ To activate Google Business Message you need to be registered as a partner with 
 
 **Get in touch with Zenvia consultants to start your account creation.**
 
-Webhooks allow you to receive events in the configured URL. [Learn more here.](#tag/Webhooks)
+To be able to send messages to a contact, you first need to setup a webhook, which allow you to receive events in the configured URL. [Learn more here](#tag/Webhooks).
+
 
 ## Google Business Message sender and recipient
 
-When you send some message for one contact using Google Business Message channel:
+When you receive a message from a contact from Google Business Message channel:
+
+* Sender: is the agent id configured on [Zenvia platform](https://app.zenvia.com/home/credentials/google-business-message/list)
+* Recipient: is the contact id
+
+When you send a message to a contact, the sender and recipient are inverted:
 
 * Recipient: is the contact id
-* Sender: is the Google Business Message agent ID configured on [Google Business Message](https://developers.google.com) and on [Zenvia platform](https://app.zenvia.com/home/credentials/google-business-message/list)
-
-When you receive a message from one contact, the sender and recipient are inverted:
-
-* Sender: is the Google Business Message agent ID configured on [Google Business Message](https://developers.google.com) and on [Zenvia platform](https://app.zenvia.com/home/credentials/google-business-message/list)
-* Recipient: is the contact id
+* Sender: is the agent id configured on [Zenvia platform](https://app.zenvia.com/home/credentials/google-business-message/list)
 
 The sender goes in the attribute `from` and the receiver goes in the attribute `to` of message object.

--- a/spec/tags/gbm.md
+++ b/spec/tags/gbm.md
@@ -4,6 +4,9 @@ To activate Google Business Message you need to be registered as a partner with 
 
 **Get in touch with Zenvia consultants to start your account creation.**
 
+
+## Limitations
+
 To be able to send messages to a contact, you first need to setup a webhook, which allow you to receive events in the configured URL. [Learn more here](#tag/Webhooks).
 
 

--- a/spec/tags/instagram.md
+++ b/spec/tags/instagram.md
@@ -5,7 +5,7 @@ Get in touch with Zenvia consultants to connect your account.
 
 ## Limitations
 
-To be able to send messages to a contact, you first need to setup a webhook, which allow you to receive events in the configured URL. [Learn more here](#tag/Webhooks).
+To be able to send messages to a contact, you first need to setup a webhook, which allows you to receive events in the configured URL. [Learn more here](#tag/Webhooks).
 
 
 The Instagram API content type and size support for sending media:

--- a/spec/tags/instagram.md
+++ b/spec/tags/instagram.md
@@ -2,12 +2,13 @@ The Instagram channel may be used after it's activation on Zenvia Platform.
 
 Get in touch with Zenvia consultants to connect your account.
 
-To be able to send messages to a contact, you first need to setup a webhook, which allow you to receive events in the configured URL. [Learn more here](#tag/Webhooks).
-
 
 ## Limitations
 
-The Instagram API content type and size support for sending messages:
+To be able to send messages to a contact, you first need to setup a webhook, which allow you to receive events in the configured URL. [Learn more here](#tag/Webhooks).
+
+
+The Instagram API content type and size support for sending media:
 
 | Media | Content Type | Media Size |
 |---|---|---|

--- a/spec/tags/instagram.md
+++ b/spec/tags/instagram.md
@@ -1,2 +1,32 @@
 The Instagram channel may be used after it's activation on Zenvia Platform.
+
 Get in touch with Zenvia consultants to connect your account.
+
+To be able to send messages to a contact, you first need to setup a webhook, which allow you to receive events in the configured URL. [Learn more here](#tag/Webhooks).
+
+
+## Limitations
+
+The Instagram API content type and size support for sending messages:
+
+| Media | Content Type | Media Size |
+|---|---|---|
+| image | image/jpeg<br>image/png<br>image/gif<br>image/ico<br>image/bmp<br>image/webp | 8 MB |
+| audio | audio/* | *Currently not supported* |
+| video | video/* | *Currently not supported* |
+| document | Any other valid MIME type. | *Currently not supported* |
+
+
+## Instagram sender and recipient
+
+When you receive a message from a contact from instagram channel:
+
+* Recipient: is your instagram account id (this is not your account @)
+* Sender: is the contact id on your account (this is not the contact @ and it will differ across accounts)
+
+When you send a message to a contact, the sender and recipient are inverted:
+
+* Recipient: is the contact id on your account (this is not the contact @ and it will differ across accounts)
+* Sender: is your instagram account id (this is not your account @)
+
+The sender goes in the attribute `from` and the receiver goes in the attribute `to` of message object.

--- a/spec/tags/rcs.md
+++ b/spec/tags/rcs.md
@@ -1,22 +1,27 @@
 The RCS channel may be used after it's activation on Zenvia Platform.
-Get in touch with Zenvia consultants to create your Google agent (An agent is a conversational entity that interacts with users by sending messages and reacting to users' responses).
+
+Get in touch with Zenvia consultants to create your Google agent (an agent is a conversational entity that interacts with users by sending messages and reacting to users' responses).
+
 
 ## Limitations
 
-The RCS channel is compatible only with smartphones Android, from 8.0 version (Oreo). 
+The RCS channel is compatible only with smartphones Android, from 8.0 version (Oreo).
+
 To enable RCS on an Android device, you can configure it with pre-release versions of the Messages and Carrier Services apps that connect it to an RCS backend.
+
 The use of RCS channel follows the Google content policies, available here: https://developers.google.com/business-communications/rcs-business-messaging/support/tos.
+
 
 ## RCS sender and recipient
 
-When you send some message for one contact using RCS channel:
+When you send a message to a contact using RCS channel:
 
-Recipient: is the phone number of contact
-Sender: is the RCS Agent ID (an email created and linked with a Zenvia's OrgID)
+Recipient: is the phone number of the contact
+Sender: is the agent id configured on [Zenvia platform](https://app.zenvia.com/home/credentials/rcs/list)
 
-When you receive a message from one contact, the sender and recipient are inverted:
+When you receive a message from a contact, the sender and recipient are inverted:
 
-Recipient: is the RCS Agent ID
-Sender: is the phone number of contact
+Recipient: is the agent id configured on [Zenvia platform](https://app.zenvia.com/home/credentials/rcs/list)
+Sender: is the phone number of the contact
 
 The sender goes in the attribute `from` and the receiver goes in the attribute `to` of message object.

--- a/spec/tags/rcs.md
+++ b/spec/tags/rcs.md
@@ -2,6 +2,8 @@ The RCS channel may be used after it's activation on Zenvia Platform.
 
 Get in touch with Zenvia consultants to create your Google agent (an agent is a conversational entity that interacts with users by sending messages and reacting to users' responses).
 
+Webhooks allow you to receive events in the configured URL. [Learn more here](#tag/Webhooks).
+
 
 ## Limitations
 

--- a/spec/tags/sms.md
+++ b/spec/tags/sms.md
@@ -4,14 +4,15 @@ The SMS channel may be used after its activation on [Zenvia platform](https://ap
 Webhooks allow you to receive events in the configured URL. [Learn more here](#tag/Webhooks).
 
 ## SMS sender and recipient
-When you send a message for one contact using SMS channel:
 
-* Recipient: is the complete phone number (including country code) of contact.
-* Sender: is the SMS account alias connected on [integrations console](https://app.zenvia.com/home/credentials).
+When you send a message to a contact using SMS channel:
 
-When you receive a message from one contact, the sender and recipient are inverted:
+* Recipient: is the complete phone number (including country code) of the contact.
+* Sender: is the SMS account alias connected on [Zenvia platform](https://app.zenvia.com/home/credentials).
 
-* Recipient: is the SMS account alias connected on [integrations console](https://app.zenvia.com/home/credentials).
-* Sender: is the complete phone number (including country code) of contact.
+When you receive a message from a contact, the sender and recipient are inverted:
+
+* Recipient: is the SMS account alias connected on [Zenvia platform](https://app.zenvia.com/home/credentials).
+* Sender: is the complete phone number (including country code) of the contact.
 
 The sender goes in the attribute `from` and the receiver goes in the attribute `to` of message object.

--- a/spec/tags/telegram.md
+++ b/spec/tags/telegram.md
@@ -20,11 +20,11 @@ Supported content types and sizes:
 When you receive a message from a contact from Telegram channel:
 
 * Recipient: is the bot username configured on [Zenvia platform](https://app.zenvia.com/home/credentials/telegram/list)
-* Sender: is the conversation id on Telegram (this is not the phone number)
+* Sender: is the conversation id (this is not the phone number)
 
 When you send a message to a contact, the sender and recipient are inverted:
 
-* Recipient: is the conversation id on Telegram (this is not the phone number)
+* Recipient: is the conversation id (this is not the phone number)
 * Sender: is the bot username configured on [Zenvia platform](https://app.zenvia.com/home/credentials/telegram/list)
 
 The sender goes in the attribute `from` and the receiver goes in the attribute `to` of message object.

--- a/spec/tags/telegram.md
+++ b/spec/tags/telegram.md
@@ -1,10 +1,9 @@
 The Telegram can be used after it's activation on Zenvia Platform.
 
-To activate Telegram you a need a registered Bot account on Telegram Bot API and an account information configured on Zenvia platform.
+To activate Telegram you a need a registered Bot account on Telegram Bot API and an account information configured on [Zenvia platform](https://app.zenvia.com/home/credentials/telegram/list).
 
-**Get in touch with Zenvia consultants to start your account creation.**
+To be able to send messages to a contact, you first need to setup a webhook, which allow you to receive events in the configured URL. [Learn more here](#tag/Webhooks).
 
-Webhooks allow you to receive events in the configured URL. [Learn more here.](#tag/Webhooks)
 
 ## Limitations
 
@@ -12,19 +11,20 @@ Supported content types and sizes:
 
 | Media | Content Type | Size |
 |---|---|---|
-| document | Any valid MIME type. | 50&nbsp;MB |
 | image | image/jpeg<br>image/png | 10&nbsp;MB |
+| document | Any other valid MIME type. | 50&nbsp;MB |
+
 
 ## Telegram sender and recipient
 
-When you send some message for one contact using Telegram channel:
+When you receive a message from a contact from Telegram channel:
 
-* Recipient: is the phone number of contact
-* Sender: is the Telegram sender id configured on [Zenvia platform](https://app.zenvia.com/home/credentials/telegram/list)
+* Recipient: is the bot username configured on [Zenvia platform](https://app.zenvia.com/home/credentials/telegram/list)
+* Sender: is the conversation id on Telegram (this is not the phone number)
 
-When you receive a message from one contact, the sender and recipient are inverted:
+When you send a message to a contact, the sender and recipient are inverted:
 
-* Recipient: is the Telegram sender id configured on [Zenvia platform](https://app.zenvia.com/home/credentials/telegram/list)
-* Sender: is the phone number of contact
+* Recipient: is the conversation id on Telegram (this is not the phone number)
+* Sender: is the bot username configured on [Zenvia platform](https://app.zenvia.com/home/credentials/telegram/list)
 
 The sender goes in the attribute `from` and the receiver goes in the attribute `to` of message object.

--- a/spec/tags/telegram.md
+++ b/spec/tags/telegram.md
@@ -5,7 +5,7 @@ To activate Telegram you a need a registered Bot account on Telegram Bot API and
 
 ## Limitations
 
-To be able to send messages to a contact, you first need to setup a webhook, which allow you to receive events in the configured URL. [Learn more here](#tag/Webhooks).
+To be able to send messages to a contact, you first need to setup a webhook, which allows you to receive events in the configured URL. [Learn more here](#tag/Webhooks).
 
 Supported content types and sizes:
 

--- a/spec/tags/telegram.md
+++ b/spec/tags/telegram.md
@@ -2,10 +2,10 @@ The Telegram can be used after it's activation on Zenvia Platform.
 
 To activate Telegram you a need a registered Bot account on Telegram Bot API and an account information configured on [Zenvia platform](https://app.zenvia.com/home/credentials/telegram/list).
 
-To be able to send messages to a contact, you first need to setup a webhook, which allow you to receive events in the configured URL. [Learn more here](#tag/Webhooks).
-
 
 ## Limitations
+
+To be able to send messages to a contact, you first need to setup a webhook, which allow you to receive events in the configured URL. [Learn more here](#tag/Webhooks).
 
 Supported content types and sizes:
 

--- a/spec/tags/voice.md
+++ b/spec/tags/voice.md
@@ -1,9 +1,11 @@
 To access  the voice channel, you need to create your account here:
 https://voice-app.zenvia.com/painel/signup.php. 
 
-After creating  the account, you can get your Access Token (SenderId) on your voice panel homepage: https://voice-app.zenvia.com/painel/
+After creating the account, you can get your voice access token on your voice panel homepage: https://voice-app.zenvia.com/painel/
 
+The voice channel may be used after you connect a voice access token on [Zenvia platform](https://app.zenvia.com/home/credentials).
 
+Webhooks allow you to receive status in the configured URL. [Learn more here.](#tag/Webhooks)
 
 Voice types for TTS (Text to Speech)
 List of available voices :
@@ -41,14 +43,14 @@ Supported content types and sizes:
 
 ## Voice sender and recipient
 
-When you send some voice message for one contact using Voice channel:
+When you send a voice message to a contact using Voice channel:
 
 * Recipient: is the phone number of the contact
-* Sender: is the Access Token got on the voice panel homepage: https://voice-app.zenvia.com/painel as mentioned above
+* Sender: is the sender id configured on [Zenvia platform](https://app.zenvia.com/home/credentials)
 
-When you receive a voice message from one contact, the sender and recipient are inverted:
+When you receive a voice message from a contact, the sender and recipient are inverted:
 
-* Recipient: is the Access Token got on the voice panel homepage: https://voice-app.zenvia.com/painel as mentioned above
+* Recipient: is the sender id configured on [Zenvia platform](https://app.zenvia.com/home/credentials)
 * Sender: is the phone number of the contact
 
 The sender goes in the attribute `from` and the receiver goes in the attribute `to` of the message object.

--- a/spec/tags/voice.md
+++ b/spec/tags/voice.md
@@ -7,33 +7,8 @@ The voice channel may be used after you connect a voice access token on [Zenvia 
 
 Webhooks allow you to receive status in the configured URL. [Learn more here.](#tag/Webhooks)
 
-Voice types for TTS (Text to Speech)
-List of available voices :
-* br-Camila
-* br-Vitoria
-* br-Ricardo
-* en-Joey
-* en-Joanna
-* fre-Celine
-* fre-Mathieu
-* ger-Vicki
-* ger-Hans
-* ita-Carla
-* ita-Giorgio
-* jap-Mizuki
-* pol-Jan
-* rus-Tatyana
-* rus-Maxim
-* esp-Conchita
-* esp-Enrique
 
 ## Limitations
-
-The Voice API has some limitations:
-
-* To send an audio file you wil have to inform the number destination and a public URL which contains the audio file.
-
-* Some additionall options are allowed such as: await for an answer, record the audio of the calling or  
 
 Supported content types and sizes:
 

--- a/spec/tags/whatsapp.md
+++ b/spec/tags/whatsapp.md
@@ -31,14 +31,14 @@ Supported content types and sizes:
 
 ## WhatsApp sender and recipient
 
-When you send some message for one contact using WhatsApp channel:
+When you send a message to a contact using WhatsApp channel:
 
-* Recipient: is the phone number of contact
+* Recipient: is the phone number of the contact
 * Sender: is the WhatsApp sender id configured on [Zenvia platform](https://app.zenvia.com/home/credentials/whatsapp/list)
 
-When you receive a message from one contact, the sender and recipient are inverted:
+When you receive a message from a contact, the sender and recipient are inverted:
 
 * Recipient: is the WhatsApp sender id configured on [Zenvia platform](https://app.zenvia.com/home/credentials/whatsapp/list)
-* Sender: is the phone number of contact
+* Sender: is the phone number of the contact
 
 The sender goes in the attribute `from` and the receiver goes in the attribute `to` of message object.


### PR DESCRIPTION
This PR is a mix of small changes that either somebody commented about and we haven't got to them, complemented by a few other stuff that I noticed, plus the integrations links that suppose to be there (exception for the Instagram channel for now).

- Updating descriptions from channels which didn't had an integration page, with integration links
- Fixing/tweaking sender/recipient ids descriptions
- Changing sending/receiving descriptions order on receptive channel
- Adding limitation on receptive channels about the "mandatory" webhook creation before being able to successfully send a message
- Removing a few redundant text, mainly the text about TTS voices which is already self-described for being an enum. 