### PR TITLE
Message sender representative

### DIFF
--- a/spec/components/schemas/content/file.ts
+++ b/spec/components/schemas/content/file.ts
@@ -20,7 +20,7 @@ const file: SchemaObject = {
       },
       fileMimeType: {
         type: 'string',
-        description: 'MIME type of the file to be sent. If not sent, the MIME type will be identified using the content type sent in the request header. For [WhatsApp channel](#tag/WhatsApp), see [supported contents and sizes.](#section/Limitations)',
+        description: 'MIME type of the file to be sent. If not sent, the MIME type will be identified using the content type sent in the request header. For [WhatsApp channel](#tag/WhatsApp), see [supported contents and sizes.](#section/WhatsApp-limitations)',
         example: 'application/pdf',
       },
       fileCaption: {

--- a/spec/components/schemas/content/whatsapp/button/header/file.ts
+++ b/spec/components/schemas/content/whatsapp/button/header/file.ts
@@ -20,7 +20,7 @@ const fileHeader: SchemaObject = {
       },
       fileMimeType: {
         type: 'string',
-        description: 'MIME type of the file to be sent. If not sent, the MIME type will be identified using the content type sent in the request header. For [WhatsApp channel](#tag/WhatsApp), see [supported contents and sizes.](#section/Limitations)',
+        description: 'MIME type of the file to be sent. If not sent, the MIME type will be identified using the content type sent in the request header. For [WhatsApp channel](#tag/WhatsApp), see [supported contents and sizes.](#section/WhatsApp-limitations)',
         example: 'application/pdf',
       },
       fileName: {

--- a/spec/components/schemas/message/gbm.ts
+++ b/spec/components/schemas/message/gbm.ts
@@ -1,6 +1,7 @@
 import { SchemaObject } from 'openapi3-ts';
 import { ref as baseRef } from './base';
 import { ref as allContentsRef } from '../content/gbm/all';
+import { ref as representativeRef } from './representative';
 import { createComponentRef } from '../../../../utils/ref';
 
 const all: SchemaObject = {
@@ -18,6 +19,9 @@ const all: SchemaObject = {
           $ref: allContentsRef,
         },
         minItems: 1,
+      },
+      representaive: {
+        $ref: representativeRef,
       },
     },
   }],

--- a/spec/components/schemas/message/instagram.ts
+++ b/spec/components/schemas/message/instagram.ts
@@ -1,6 +1,7 @@
 import { SchemaObject } from 'openapi3-ts';
 import { ref as baseRef } from './base';
 import { ref as allContentsRef } from '../content/instagram/all';
+import { ref as representativeRef } from './representative';
 import { createComponentRef } from '../../../../utils/ref';
 
 const all: SchemaObject = {
@@ -18,6 +19,9 @@ const all: SchemaObject = {
           $ref: allContentsRef,
         },
         minItems: 1,
+      },
+      representaive: {
+        $ref: representativeRef,
       },
     },
   }],

--- a/spec/components/schemas/message/representative.ts
+++ b/spec/components/schemas/message/representative.ts
@@ -1,0 +1,36 @@
+import { SchemaObject } from 'openapi3-ts';
+import { createComponentRef } from '../../../../utils/ref';
+
+const representative: SchemaObject = {
+  title: 'Representative Object',
+  description: `It provides information about the representative who sent the message.
+                <br>It is mainly meant to be used when a **human** agent is the message's sender.
+                <br><br>*Only applicable to [Instagram](#tag/Instagram) and [Google Business Message](#tag/Google-Business-Message) channels.*`,
+  type: 'object',
+  properties: {
+    type: {
+      title: 'Type',
+      description: `Indicates whether the message sender is a *bot* or a *human* agent.
+                    <br>The \`HUMAN\` value must be only used on a **human** agent message.`,
+      type: 'string',
+      enum: ['BOT', 'HUMAN'],
+      default: 'BOT',
+    },
+    name: {
+      title: 'Name',
+      description: `Representative's name shown on the message.
+                    <br>*Only applicable to [Google Business channel](#tag/Google-Business-Message).*`,
+      type: 'string',
+    },
+    picture: {
+      title: 'Picture',
+      description: `URL for the avatar picture of the representative message.
+                    <br>*Only applicable to [Google Business channel](#tag/Google-Business-Message).*`,
+      type: 'string',
+    },
+
+  },
+};
+
+export const ref = createComponentRef(__filename);
+export default representative;

--- a/spec/components/schemas/message/representative.ts
+++ b/spec/components/schemas/message/representative.ts
@@ -11,7 +11,7 @@ const representative: SchemaObject = {
     type: {
       title: 'Type',
       description: `Indicates whether the message sender is a *bot* or a *human* agent.
-                    <br>The \`HUMAN\` value must be only used on a **human** agent message.`,
+                    <br>The \`HUMAN\` value must only be used on a **human** agent message.`,
       type: 'string',
       enum: ['BOT', 'HUMAN'],
       default: 'BOT',

--- a/spec/components/schemas/message/representative.ts
+++ b/spec/components/schemas/message/representative.ts
@@ -19,13 +19,13 @@ const representative: SchemaObject = {
     name: {
       title: 'Name',
       description: `Representative's name shown on the message.
-                    <br>*Only applicable to [Google Business channel](#tag/Google-Business-Message).*`,
+                    <br>*Only applicable to [Google Business Message channel](#tag/Google-Business-Message).*`,
       type: 'string',
     },
     picture: {
       title: 'Picture',
       description: `URL for the avatar picture of the representative message.
-                    <br>*Only applicable to [Google Business channel](#tag/Google-Business-Message).*`,
+                    <br>*Only applicable to [Google Business Message channel](#tag/Google-Business-Message).*`,
       type: 'string',
     },
 

--- a/spec/components/schemas/message/visitor.ts
+++ b/spec/components/schemas/message/visitor.ts
@@ -6,7 +6,7 @@ const visitor: SchemaObject = {
   description: `It provides information about the contact who sent the message.
                 <br>The availability of this information depends on privacy settings of the contact.
                 <br><br>*Only applicable to [WhatsApp](#tag/WhatsApp), [Instagram](#tag/Instagram),
-                [Facebook](#tag/Facebook) and [Telegram](#tag/Telegram) channels.*`,
+                [Facebook](#tag/Facebook), [Telegram](#tag/Telegram) and [Google Business Message](#tag/Google-Business-Message) channels.*`,
   type: 'object',
   properties: {
     name: {

--- a/spec/tags/facebook.md
+++ b/spec/tags/facebook.md
@@ -1,7 +1,7 @@
 The Facebook channel may be used after you connect a Facebook Page on [Zenvia platform](https://app.zenvia.com/home/credentials/facebook/list).
 
 
-## Limitations
+## Facebook limitations
 
 To be able to send messages to a contact, you first need to setup a webhook, which allows you to receive events in the configured URL. [Learn more here](#tag/Webhooks).
 

--- a/spec/tags/gbm.md
+++ b/spec/tags/gbm.md
@@ -5,7 +5,7 @@ To activate Google Business Message you need to be registered as a partner with 
 **Get in touch with Zenvia consultants to start your account creation.**
 
 
-## Limitations
+## Google Business Message limitations
 
 To be able to send messages to a contact, you first need to setup a webhook, which allows you to receive events in the configured URL. [Learn more here](#tag/Webhooks).
 

--- a/spec/tags/instagram.md
+++ b/spec/tags/instagram.md
@@ -5,9 +5,11 @@ Get in touch with Zenvia consultants to connect your account.
 
 ## Instagram limitations
 
-To be able to send messages to a contact, you first need to setup a webhook, which allows you to receive events in the configured URL. [Learn more here](#tag/Webhooks).
+* To be able to send messages to a contact, you first need to setup a webhook, which allows you to receive events in the configured URL. [Learn more here](#tag/Webhooks).
 
+* The response window is *24 hours*, with the exception when a human agent is replying the contact, then the response window is increased to 7 days.
 
+<br>
 The Instagram API content type and size support for sending media:
 
 | Media | Content Type | Media Size |

--- a/spec/tags/instagram.md
+++ b/spec/tags/instagram.md
@@ -3,7 +3,7 @@ The Instagram channel may be used after it's activation on Zenvia Platform.
 Get in touch with Zenvia consultants to connect your account.
 
 
-## Limitations
+## Instagram limitations
 
 To be able to send messages to a contact, you first need to setup a webhook, which allows you to receive events in the configured URL. [Learn more here](#tag/Webhooks).
 

--- a/spec/tags/rcs.md
+++ b/spec/tags/rcs.md
@@ -5,7 +5,7 @@ Get in touch with Zenvia consultants to create your Google agent (an agent is a 
 Webhooks allow you to receive events in the configured URL. [Learn more here](#tag/Webhooks).
 
 
-## Limitations
+## RCS limitations
 
 The RCS channel is compatible only with smartphones Android, from 8.0 version (Oreo).
 

--- a/spec/tags/telegram.md
+++ b/spec/tags/telegram.md
@@ -3,7 +3,7 @@ The Telegram can be used after it's activation on Zenvia Platform.
 To activate Telegram you a need a registered Bot account on Telegram Bot API and an account information configured on [Zenvia platform](https://app.zenvia.com/home/credentials/telegram/list).
 
 
-## Limitations
+## Telegram limitations
 
 To be able to send messages to a contact, you first need to setup a webhook, which allows you to receive events in the configured URL. [Learn more here](#tag/Webhooks).
 

--- a/spec/tags/voice.md
+++ b/spec/tags/voice.md
@@ -8,7 +8,7 @@ The voice channel may be used after you connect a voice access token on [Zenvia 
 Webhooks allow you to receive status in the configured URL. [Learn more here.](#tag/Webhooks)
 
 
-## Limitations
+## Voice limitations
 
 Supported content types and sizes:
 

--- a/spec/tags/whatsapp.md
+++ b/spec/tags/whatsapp.md
@@ -7,7 +7,7 @@ To activate WhatsApp you a need a registered number on WhatsApp Business API and
 Webhooks allow you to receive events in the configured URL. [Learn more here.](#tag/Webhooks)
 
 
-## Limitations
+## WhatsApp limitations
 
 The WhatsApp API has some limitations:
 
@@ -17,6 +17,7 @@ The WhatsApp API has some limitations:
 
 * When sending PNG images with a **transparent background**, you can get an unexpected final result due to the image processing performed by WhatsApp in order to convert the image to JPEG.
 
+<br>
 Supported content types and sizes:
 
 | Media | Content Type | Post-Processing Media Size* |


### PR DESCRIPTION
Including the option to define who is the representative sending the message.

I have only add the representative field to the Instagram and GBM schemas.

I have also update the name of the "Limitations" sections to be unique (as it was done to the "sender and recipient" sections).

Here it is the representative schema description on the post message:
![Screenshot_2021-08-25 ZenAPI API Reference](https://user-images.githubusercontent.com/4666758/130729695-62a3a14a-47da-45fd-8e3f-2f661d6c187c.png)

I have also update the "Instagram limitations" section:
![Screenshot_2021-08-25 ZenAPI API Reference-L](https://user-images.githubusercontent.com/4666758/130729813-a8fee335-9982-444e-b2db-d917a6af9e54.png)
