### PR TITLE
Melhorando descrição do item rows para mensagens de lista interativas

### DIFF
--- a/spec/components/schemas/content/whatsapp/list.ts
+++ b/spec/components/schemas/content/whatsapp/list.ts
@@ -50,6 +50,7 @@ const list: SchemaObject = {
             },
             rows: {
               type: 'array',
+              description: 'Max of 10 rows considering all sections together.',
               minItems: 1,
               maxItems: 10,
               items: {


### PR DESCRIPTION
Especificando o limite de linhas nas mensagens interativas de lista:
Whatsapp coloca um limite total de 10 linhas somando todas as seções juntas.

