### PR TITLE
idRef description and all contents on message webhook

### DIFF
--- a/spec/components/schemas/content/all.ts
+++ b/spec/components/schemas/content/all.ts
@@ -1,0 +1,33 @@
+import { SchemaObject } from 'openapi3-ts';
+import { ref as allWhatsContentsRef } from '../content/whatsapp/all';
+import { ref as allInstaContentsRef } from '../content/instagram/all';
+import { ref as allSmsContentsRef } from '../content/sms/all';
+import { ref as allFaceContentsRef } from '../content/facebook/all';
+import { ref as allRcsContentsRef } from '../content/rcs/all';
+import { ref as allVoiceContentsRef } from '../content/voice/all';
+import { ref as allTelegramContentsRef } from '../content/telegram/all';
+import { ref as allGbmContentsRef } from '../content/gbm/all';
+import { createComponentRef } from '../../../../utils/ref';
+
+const all: SchemaObject = {
+  anyOf: [{
+    $ref: allWhatsContentsRef,
+  }, {
+    $ref: allInstaContentsRef,
+  }, {
+    $ref: allSmsContentsRef,
+  }, {
+    $ref: allFaceContentsRef,
+  }, {
+    $ref: allRcsContentsRef,
+  }, {
+    $ref: allVoiceContentsRef,
+  }, {
+    $ref: allTelegramContentsRef,
+  }, {
+    $ref: allGbmContentsRef,
+  }],
+};
+
+export const ref = createComponentRef(__filename);
+export default all;

--- a/spec/components/schemas/content/facebook/all.ts
+++ b/spec/components/schemas/content/facebook/all.ts
@@ -7,6 +7,7 @@ import { ref as carouselRef } from '../carousel';
 import { createComponentRef } from '../../../../../utils/ref';
 
 const all: SchemaObject = {
+  title: 'Facebook',
   oneOf: [{
     $ref: textRef,
   }, {

--- a/spec/components/schemas/content/gbm/all.ts
+++ b/spec/components/schemas/content/gbm/all.ts
@@ -4,6 +4,7 @@ import { ref as fileRef } from '../file';
 import { createComponentRef } from '../../../../../utils/ref';
 
 const all: SchemaObject = {
+  title: 'Google Business Messages',
   oneOf: [{
     $ref: textRef,
   }, {

--- a/spec/components/schemas/content/instagram/all.ts
+++ b/spec/components/schemas/content/instagram/all.ts
@@ -5,6 +5,7 @@ import { ref as quickRepliesRef } from '../replyable-text';
 import { createComponentRef } from '../../../../../utils/ref';
 
 const all: SchemaObject = {
+  title: 'Instagram',
   oneOf: [{
     $ref: textRef,
   }, {

--- a/spec/components/schemas/content/rcs/all.ts
+++ b/spec/components/schemas/content/rcs/all.ts
@@ -7,6 +7,7 @@ import { ref as quickRepliesRef } from '../replyable-text';
 import { createComponentRef } from '../../../../../utils/ref';
 
 const all: SchemaObject = {
+  title: 'RCS',
   oneOf: [{
     $ref: textRef,
   }, {

--- a/spec/components/schemas/content/sms/all.ts
+++ b/spec/components/schemas/content/sms/all.ts
@@ -3,6 +3,7 @@ import { ref as textRef } from './text';
 import { createComponentRef } from '../../../../../utils/ref';
 
 const all: SchemaObject = {
+  title: 'SMS',
   oneOf: [{
     $ref: textRef,
   }],

--- a/spec/components/schemas/content/telegram/all.ts
+++ b/spec/components/schemas/content/telegram/all.ts
@@ -4,6 +4,7 @@ import { ref as fileRef } from '../file';
 import { createComponentRef } from '../../../../../utils/ref';
 
 const all: SchemaObject = {
+  title: 'Telegram',
   oneOf: [{
     $ref: textRef,
   }, {

--- a/spec/components/schemas/content/voice/all.ts
+++ b/spec/components/schemas/content/voice/all.ts
@@ -3,6 +3,7 @@ import { ref as callRef } from '../call';
 import { createComponentRef } from '../../../../../utils/ref';
 
 const all: SchemaObject = {
+  title: 'Voice',
   oneOf: [{
     $ref: callRef,
   }],

--- a/spec/components/schemas/content/whatsapp/all.ts
+++ b/spec/components/schemas/content/whatsapp/all.ts
@@ -9,7 +9,7 @@ import { ref as listRef } from './list';
 import { createComponentRef } from '../../../../../utils/ref';
 
 const all: SchemaObject = {
-  title: 'Whatsapp',
+  title: 'WhatsApp',
   oneOf: [{
     $ref: textRef,
   }, {

--- a/spec/components/schemas/content/whatsapp/all.ts
+++ b/spec/components/schemas/content/whatsapp/all.ts
@@ -9,6 +9,7 @@ import { ref as listRef } from './list';
 import { createComponentRef } from '../../../../../utils/ref';
 
 const all: SchemaObject = {
+  title: 'Whatsapp',
   oneOf: [{
     $ref: textRef,
   }, {

--- a/spec/components/schemas/message/all.ts
+++ b/spec/components/schemas/message/all.ts
@@ -25,7 +25,7 @@ const all: SchemaObject = {
       },
       idRef: {
         title: 'Referenced Message ID',
-        description: `When a user sends a message quoting a previous message, the identifier of the quoted message will be provided here.
+        description: `When a user sends a message quoting a previous message, the identifier of the quoted message will be provided here. Also:
 * On reply button clicks (see [replyable text](#section/Replyable-Text) and [card](#section/Card) sections), this will refer to the ID of the clicked message.
 * On [SMS channel](#tag/SMS), this will refer to the ID of the last message sent to the contact.
 

--- a/spec/components/schemas/message/all.ts
+++ b/spec/components/schemas/message/all.ts
@@ -19,13 +19,9 @@ const all: SchemaObject = {
         $ref: referralSchemaRef,
       },
       contents: {
-        title: 'Message Contents',
-        description: 'A list of content to be sent',
-        type: 'array',
         items: {
           $ref: allContentsRef,
         },
-        minItems: 1,
       },
       idRef: {
         title: 'Referenced Message ID',

--- a/spec/components/schemas/message/all.ts
+++ b/spec/components/schemas/message/all.ts
@@ -28,9 +28,12 @@ const all: SchemaObject = {
         minItems: 1,
       },
       idRef: {
+        title: 'Referenced Message ID',
         description: `When a user sends a message quoting a previous message, the identifier of the quoted message will be provided here.
-                      On [SMS channel](#tag/SMS), this is the ID of the last message sent to the contact.
-                      <br><br>*Only applicable to [WhatsApp](#tag/WhatsApp), [Instagram](#tag/Instagram) and [SMS](#tag/SMS) channels.*`,
+* On reply button clicks (see [replyable text](#section/Replyable-Text) and [card](#section/Card) sections), this will refer to the ID of the clicked message.
+* On [SMS channel](#tag/SMS), this will refer to the ID of the last message sent to the contact.
+
+*Only applicable to [WhatsApp](#tag/WhatsApp), [Instagram](#tag/Instagram), [SMS](#tag/SMS), [Facebook](#tag/Facebook) and [RCS](#tag/RCS) channels.*`,
         type: 'string',
         readOnly: true,
       },

--- a/spec/components/schemas/message/all.ts
+++ b/spec/components/schemas/message/all.ts
@@ -1,6 +1,6 @@
 import { SchemaObject } from 'openapi3-ts';
 import { ref as baseRef } from './base';
-import { ref as allContentsRef } from '../content/whatsapp/all';
+import { ref as allContentsRef } from '../content/all';
 import { createComponentRef } from '../../../../utils/ref';
 import { ref as visitorSchemaRef } from './visitor';
 import { ref as referralSchemaRef } from './referral';

--- a/spec/components/schemas/message/base.ts
+++ b/spec/components/schemas/message/base.ts
@@ -46,7 +46,7 @@ const base: SchemaObject = {
     },
     contents: {
       title: 'Message Contents',
-      description: 'A list of content to be sent',
+      description: 'The list of contents to be sent',
       type: 'array',
       items: {
         type: 'object',


### PR DESCRIPTION
The initial objective was to update the idRef description:
![Screenshot 2021-12-01 at 15-55-04 ZenAPI API Reference](https://user-images.githubusercontent.com/4666758/144312769-2154db40-8c0a-45af-833c-80cfafc0d17d.png)

However, I noticed only the Whatsapp contents were show in the message webhook (although so far direction OUT is still not implemented, so only text is really used).

When trying to list all contents, I accidentally discovered that is possible to show them organized by channel, which I found to be pretty cool, so I kept this way.
![Screenshot 2021-12-01 at 17-51-23 ZenAPI API Reference](https://user-images.githubusercontent.com/4666758/144313134-141a8fb8-bca8-4c2f-92b3-b4c6e57421cb.png)
