### PR TITLE
[CON-571] Add a sharing type to referral object

### DIFF
--- a/spec/components/schemas/message/referral.ts
+++ b/spec/components/schemas/message/referral.ts
@@ -40,7 +40,7 @@ const referral: SchemaObject = {
           title: 'Type',
           description: 'The type of content where the message originated.',
           type: 'string',
-          enum: ['ad', 'post', 'story_mention', 'story', 'message', 'live'],
+          enum: ['ad', 'post', 'story_mention', 'sharing', 'story', 'message', 'live'],
         },
         url: {
           title: 'URL',


### PR DESCRIPTION
Added to zenAPI for referral object, the type `sharing`. This type will used when occurs a content sharing.
