### PR TITLE
docs: correcao de texto

### DIFF
--- a/spec/tags/email.md
+++ b/spec/tags/email.md
@@ -9,28 +9,27 @@ You either can use one of the Zenvia domains provided in the e-mail activation c
 
 However, to use your domain, your will need to change or create DNS entries to make this possible.
 
-The way to do this will be described in the activation console e-mail [Zenvia platform](https://app.zenvia.com/home/credentials/email/list)
+The way to do this will be described on the [e-mail activation console](https://app.zenvia.com/home/credentials/email/list)
 
 <br>
 Supported content types and sizes:
 
-| Media | Content Type | E-Mail Size* |
-|---|---|---|
-| document | Any valid MIME type. | 25&nbsp;MB |
+| Media    | Content Type         | E-Mail Size\* |
+| -------- | -------------------- | ------------- |
+| document | Any valid MIME type. | 25&nbsp;MB    |
 
-*The maximum size is for the entire e-mail.
-
+\*The maximum size is for the entire e-mail.
 
 ## E-Mail sender and recipient
 
 When you send a message to a contact using E-Mail channel:
 
-* Recipient: the e-mail address of the contact.
-* Sender: the e-mail address connected on [Zenvia platform](https://app.zenvia.com/home/credentials/email/list).
+- Recipient: the e-mail address of the contact.
+- Sender: the e-mail address connected on [Zenvia platform](https://app.zenvia.com/home/credentials/email/list).
 
 When you receive a message from a contact, the sender and recipient are inverted:
 
-* Recipient: the e-mail address connected on [Zenvia platform](https://app.zenvia.com/home/credentials/email/list).
-* Sender: the e-mail address of the contact.
+- Recipient: the e-mail address connected on [Zenvia platform](https://app.zenvia.com/home/credentials/email/list).
+- Sender: the e-mail address of the contact.
 
 The sender goes in the attribute `from` and the receiver goes in the attribute `to` of message object.


### PR DESCRIPTION
Carioca comentou que não era um **e-mail** que seria recebido (um e-mail de activation console), mas de fato a forma de usar o canal e-mail seria ativá-lo no **console de e-mail**.
Os outros _file changes_ foram correções do linter ou validator

Esse PR faz a correção citada acima e o link para o Jira segue:
https://zenvia.atlassian.net/browse/CON-653?atlOrigin=eyJpIjoiMjVjYzAyMTIzZDMxNGJmYmE2NThjZGFkNTM0NDZkMzIiLCJwIjoiaiJ9