### PR TITLE
add new categories

### DIFF
--- a/spec/components/schemas/templates/template-category.ts
+++ b/spec/components/schemas/templates/template-category.ts
@@ -18,6 +18,9 @@ const category: SchemaObject = {
     'TICKET_UPDATE',
     'ALERT_UPDATE',
     'AUTO_REPLY',
+    'AUTHENTICATION',
+    'MARKETING',
+    'UTILITY',
   ],
 };
 


### PR DESCRIPTION
Com as novas categorias da Meta de WhatsApp, clientes que utilizem a API v1 ficariam sem conseguir consultar seus templates depois de atualizados