### PR TITLE
Adding size to list all templates page

### DIFF
--- a/spec/components/parameters/templates/page.ts
+++ b/spec/components/parameters/templates/page.ts
@@ -1,0 +1,18 @@
+import { ParameterObject } from 'openapi3-ts';
+import { createComponentRef } from '../../../../utils/ref';
+
+const page: ParameterObject = {
+  name: 'page',
+  in: 'query',
+  required: false,
+  description: 'This is the page number.',
+  schema: {
+    title: 'page',
+    type: 'number',
+    default: 1,
+  },
+  example: 5,
+};
+
+export const ref = createComponentRef(__filename);
+export default page;

--- a/spec/components/parameters/templates/size.ts
+++ b/spec/components/parameters/templates/size.ts
@@ -1,0 +1,18 @@
+import { ParameterObject } from 'openapi3-ts';
+import { createComponentRef } from '../../../../utils/ref';
+
+const size: ParameterObject = {
+  name: 'size',
+  in: 'query',
+  required: false,
+  description: 'This is the page size.',
+  schema: {
+    title: 'size',
+    type: 'number',
+    default: 500,
+  },
+  example: 10,
+};
+
+export const ref = createComponentRef(__filename);
+export default size;

--- a/spec/paths/templates/templates.ts
+++ b/spec/paths/templates/templates.ts
@@ -12,7 +12,7 @@ import { ref as channel } from '../../components/parameters/templates/channel';
 import { ref as senderId } from '../../components/parameters/templates/senderId';
 import { ref as status } from '../../components/parameters/templates/status';
 import { ref as size } from '../../components/parameters/templates/size';
-import { ref as page } from '../../components/parameters/page';
+import { ref as page } from '../../components/parameters/templates/page';
 
 const post: OperationObject = {
   description: 'Create a new template',

--- a/spec/paths/templates/templates.ts
+++ b/spec/paths/templates/templates.ts
@@ -11,6 +11,7 @@ import { ref as errorResponseRef } from '../../components/responses/error';
 import { ref as channel } from '../../components/parameters/templates/channel';
 import { ref as senderId } from '../../components/parameters/templates/senderId';
 import { ref as status } from '../../components/parameters/templates/status';
+import { ref as size } from '../../components/parameters/templates/size';
 
 const post: OperationObject = {
   description: 'Create a new template',
@@ -53,6 +54,9 @@ const get: OperationObject = {
     },
     {
       $ref: status,
+    },
+    {
+      $ref: size,
     },
   ],
   responses: {

--- a/spec/paths/templates/templates.ts
+++ b/spec/paths/templates/templates.ts
@@ -12,6 +12,7 @@ import { ref as channel } from '../../components/parameters/templates/channel';
 import { ref as senderId } from '../../components/parameters/templates/senderId';
 import { ref as status } from '../../components/parameters/templates/status';
 import { ref as size } from '../../components/parameters/templates/size';
+import { ref as page } from '../../components/parameters/page';
 
 const post: OperationObject = {
   description: 'Create a new template',
@@ -56,6 +57,9 @@ const get: OperationObject = {
       $ref: status,
     },
     {
+      $ref: page,
+    },
+    {
       $ref: size,
     },
   ],
@@ -70,6 +74,29 @@ const get: OperationObject = {
               $ref: templateSchemaRef,
             },
           } as SchemaObject,
+        },
+      },
+      headers: {
+        'x-total': {
+          schema: {
+            description: 'The total number of results available.',
+            type: 'string',
+            example: '100',
+          },
+        },
+        'x-page-size': {
+          schema: {
+            description: 'The number of results per page.',
+            type: 'string',
+            example: '10',
+          },
+        },
+        'x-page': {
+          schema: {
+            description: 'The current page.',
+            type: 'string',
+            example: '5',
+          },
         },
       },
     } as ResponseObject,


### PR DESCRIPTION
**O que foi feito:** Adicionado o campo 'size' na página de listagem de templates, atualizando a página para seguir as modificações feitas em back-end.

**Resultado:** 

![image](https://github.com/zenvia/zenvia-openapi-spec/assets/37602367/27d1719a-ee05-4d4c-abae-4209abc49a8f)
![image](https://github.com/zenvia/zenvia-openapi-spec/assets/37602367/bc40d776-87a3-4007-99ec-a4241a3c9345)
