### PR TITLE
chore/adding-health-status-endpoints

### DIFF
--- a/spec/components/schemas/status-groups/status-groups.ts
+++ b/spec/components/schemas/status-groups/status-groups.ts
@@ -1,0 +1,129 @@
+// tslint:disable:max-line-length
+import { SchemaObject } from 'openapi3-ts';
+import { createComponentRef } from '../../../../utils/ref';
+
+const statusGroups: SchemaObject = {
+  title: 'Status Groups',
+  description: 'Status Groups information.',
+  type: 'object',
+  properties: {
+    id: {
+      title: 'ID',
+      description: 'ID of the Zenvia plataform/service.',
+      type: 'string',
+      readOnly: true,
+      example: 'whatsapp'
+    },
+    name: {
+      title: 'Name',
+      description: 'Name of the Zenvia plataform/service.',
+      type: 'string',
+      example: 'whatsapp',
+    },
+    type: {
+      title: 'Type',
+      description: 'Type of the Status Group.',
+      type: 'string',
+      enum: [
+        'system',
+        'configured',
+      ],
+      example: 'configured',
+    },
+    status: {
+      title: 'Status',
+      description: 'Indicates the status of a Zenvia group or component',
+      type: 'string',
+      enum: [
+        'UP',
+        'UNKNOWN',
+        'WARNING',
+        'DOWN',
+      ],
+      example: 'UP',
+    },
+    timestamp: {
+      title: 'Timestamp',
+      description: 'Indicates the moment in which the state was generated.',
+      type: 'string',
+      example: '2022-05-23T19:37:59.000Z',
+      readOnly: true,
+    },
+    window: {
+      title: 'Window',
+      description: 'Indicates the time window that the state represents.',
+      type: 'object',
+      properties: {
+        seconds: {
+          title: 'Seconds',
+          description: 'Size of the time window.',
+          type: 'number',
+          example: '60',
+        },
+        timestamp: {
+          title: 'Timestamp',
+          description: 'Beginning of the time window.',
+          type: 'string',
+          example: '2023-02-23T19:37:00Z',
+        },
+        id: {
+          title: 'Id',
+          description: 'Identifier of the time window.',
+          type: 'number',
+          example: '27929555',
+        },
+      },
+    },
+    components: {
+      title: 'Components',
+      description: 'Components that are a part of the status.',
+      type: 'array',
+      items: {
+        title: 'Components',
+        description: 'Components that are a part of the status.',
+        type: 'object',
+        properties: {
+          id: {
+            title: 'Id',
+            description: 'Identifier of a component of the status groups.',
+            type: 'string',
+            example: 'core-api',
+          },
+          name: {
+            title: 'Name',
+            description: 'Name of a component of the status groups.',
+            type: 'string',
+            example: 'Platform',
+          },
+          phone: {
+            title: 'Phone',
+            description: 'Phone of a component of the status groups. Specific for configured type components.',
+            type: 'string',
+            example: '01310-300',
+          },
+          uri: {
+            title: 'Uri',
+            description: 'Uri of a component of the status groups. Specific for configured type components.',
+            type: 'string',
+            example: 'http://webhook.com/',
+          },
+          status: {
+            title: 'Status',
+            description: 'Status of a component of the status groups.',
+            type: 'string',
+            enum: [
+              'UP',
+              'UNKNOWN',
+              'WARNING',
+              'DOWN',
+            ],
+            example: 'UP',
+          },
+        },
+      },
+    },
+  },
+};
+
+export const ref = createComponentRef(__filename);
+export default statusGroups;

--- a/spec/paths/status-groups/status-groups.ts
+++ b/spec/paths/status-groups/status-groups.ts
@@ -1,0 +1,33 @@
+import { PathItemObject, OperationObject, ResponseObject, SchemaObject } from 'openapi3-ts';
+import { ref as errorResponseRef } from '../../components/responses/error';
+import { ref as statusGroupsRef } from '../../components/schemas/status-groups/status-groups';
+
+const get: OperationObject = {
+  summary: 'Check groups status',
+  description: 'Allows monitoring of the status of Zenvia platforms and solutions.',
+  tags: ['Status Groups'],
+  responses: {
+    200: {
+      description: 'Status Groups successfully executed',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'array',
+            items: {
+              $ref: statusGroupsRef,
+            },
+          } as SchemaObject,
+        },
+      },
+    } as ResponseObject,
+    default: {
+      $ref: errorResponseRef,
+    },
+  },
+};
+
+const path: PathItemObject = {
+  get,
+};
+
+export default path;

--- a/spec/paths/status-groups/status-groups@{id}.ts
+++ b/spec/paths/status-groups/status-groups@{id}.ts
@@ -1,0 +1,30 @@
+import { PathItemObject, OperationObject, ResponseObject, ResponsesObject } from 'openapi3-ts';
+import { ref as errorResponseRef } from '../../components/responses/error';
+import { ref as statusGroupsRef } from '../../components/schemas/status-groups/status-groups';
+
+const get: OperationObject = {
+  summary: 'Check groups status by id',
+  description: 'Allows monitoring of the status of a single Zenvia platform and solution.',
+  tags: ['Status Groups'],
+  responses: {
+    200: {
+      description: 'Status Groups object',
+      content: {
+        'application/json': {
+          schema: {
+            $ref: statusGroupsRef,
+          },
+        },
+      },
+    } as ResponseObject,
+    default: {
+      $ref: errorResponseRef,
+    },
+  } as ResponsesObject,
+};
+
+const path: PathItemObject = {
+  get
+};
+
+export default path;

--- a/spec/tags/groups.ts
+++ b/spec/tags/groups.ts
@@ -54,6 +54,11 @@ const groups: TagGroupObject[] = [{
   tags: [
     'Marketing Automations',
   ],
+}, {
+  name: 'Status Groups',
+  tags: [
+    'Status Groups',
+  ],
 }];
 
 export default groups;

--- a/spec/tags/index.ts
+++ b/spec/tags/index.ts
@@ -20,6 +20,7 @@ const emailDescription = rawLoad(__dirname, './email.md');
 const filesDescription = rawLoad(__dirname, './files.md');
 const twoFactorAuthentication = rawLoad(__dirname, './2fa.md');
 const marketingAutomationDescription = rawLoad(__dirname, './marketing-automations.md');
+const statusGroupsDescription = rawLoad(__dirname, './status-groups.md');
 
 const tags: TagObject[] = [{
   name: 'Content types',
@@ -78,6 +79,9 @@ const tags: TagObject[] = [{
 }, {
   name: 'Marketing Automations',
   description: marketingAutomationDescription,
+},{
+  name: 'Status Groups',
+  description: statusGroupsDescription,
 }];
 
 export default tags;

--- a/spec/tags/status-groups.md
+++ b/spec/tags/status-groups.md
@@ -1,0 +1,1 @@
+Centralized API for status and monitoring of Zenvia platforms and solutions. This API can be used by customers who need to monitor our services for better understanding.


### PR DESCRIPTION
**Dor:** Necessidade de adicionar os endpoints para o status groups na documentação Zenvia para atualizá-la

**O que foi feito:** 
- Adicionada página de status groups com exemplificação e explicação dos campos retornados após a utilização dos endpoints

**Resultados:**
![image](https://github.com/zenvia/zenvia-openapi-spec/assets/37602367/fd0c47f5-3bc9-46a6-b3b5-af297cdba447)
![image](https://github.com/zenvia/zenvia-openapi-spec/assets/37602367/c22c8950-14f6-4530-ac93-a07a15287dda)
![image](https://github.com/zenvia/zenvia-openapi-spec/assets/37602367/6e271e6d-d5c4-4994-bf70-078150acf6b9)
![image](https://github.com/zenvia/zenvia-openapi-spec/assets/37602367/20d0b555-378f-4ecf-a99b-42f273fa7b58)
