### PR TITLE
Feat/contacts-management routes improvements

### DIFF
--- a/spec/components/schemas/contacts-management/contact.ts
+++ b/spec/components/schemas/contacts-management/contact.ts
@@ -79,7 +79,6 @@ const base: SchemaObject = {
           title: 'Boolean',
           example: true,
         }],
-        nullable: true,
       },
     },
     addresses: {

--- a/spec/components/schemas/contacts-management/contact.ts
+++ b/spec/components/schemas/contacts-management/contact.ts
@@ -79,6 +79,7 @@ const base: SchemaObject = {
           title: 'Boolean',
           example: true,
         }],
+        nullable: true,
       },
     },
     addresses: {

--- a/spec/components/schemas/contacts-management/contact.ts
+++ b/spec/components/schemas/contacts-management/contact.ts
@@ -53,6 +53,12 @@ const base: SchemaObject = {
       type: 'string',
       example: 'Souza',
     },
+    birthdate: {
+      title: 'Birthdate',
+      description: 'Contact\'s birthdate',
+      type: 'string',
+      example: '1970-06-13',
+    },
     customData: {
       title: 'Custom Data',
       description: 'Set values for contact custom data fields created on [contact data fields API](#tag/Contacts/paths/~1contacts-data-fields/post).',


### PR DESCRIPTION
## What was done?
1. Added Contact's birthdate field in Contact Schema.
2. Allow Contact's custom data fields to be null.

## Why it was done?
1. To allow contact's birthdate setting.
2. To fix issue that happens when trying to list a contact that has extra fields with `null` values.