### PR TITLE
[WHAT-3450] chore/add-coupon-templates

### DIFF
--- a/spec/components/schemas/content/template.ts
+++ b/spec/components/schemas/content/template.ts
@@ -23,7 +23,8 @@ const template: SchemaObject = {
         type: 'object',
         description: 'The available fields to be used in this template.<br><br>\
         For media templates, the media URL is obtained from `imageUrl`, `videoUrl` or `documentUrl` depending on the template used.<br><br>\
-        For WhatsApp authentication templates, pass the `token` parameter and its value. It is required.',
+        For WhatsApp authentication templates, pass the `token` parameter and its value. It is required.<br><br>\
+        For WhatsApp coupon templates, pass the `code` parameter and its value. It is required.',
         example: {
           user: 'John Smith',
           protocol: '34534252',

--- a/spec/components/schemas/templates/components/buttons/actions.ts
+++ b/spec/components/schemas/templates/components/buttons/actions.ts
@@ -5,6 +5,7 @@ import { ref as baseRef } from './base';
 import { ref as urlRef } from './button-item-url';
 import { ref as phoneNumberRef } from './button-item-phone-number';
 import { ref as mpmRef } from './button-item-mpm';
+import { ref as copyCodeRef } from './button-item-coupon';
 
 const buttons: SchemaObject = {
   type: 'object',
@@ -15,7 +16,7 @@ const buttons: SchemaObject = {
     properties: {
       items: {
         title: 'Buttons',
-        description: 'List of buttons. Only one of the following can be included: URL, MPM, or PHONE_NUMBER. MPM buttons are exclusively for use in [WHATSAPP](tag#WHATSAPP).',
+        description: 'List of buttons. Only one of the following can be included: URL, MPM, PHONE_NUMBER or COPY_CODE. MPM and COPY_CODE buttons are exclusively for use in [WHATSAPP](tag#WHATSAPP).',
         maxItems: 2,
         type: 'array',
         items: {
@@ -27,6 +28,9 @@ const buttons: SchemaObject = {
           },
           {
             $ref: mpmRef,
+          },
+          {
+            $ref: copyCodeRef,
           }],
           required: [
             'type',
@@ -37,6 +41,7 @@ const buttons: SchemaObject = {
               URL: urlRef,
               PHONE_NUMBER: phoneNumberRef,
               MPM: mpmRef,
+              COPY_CODE: copyCodeRef,
             },
           },
         },

--- a/spec/components/schemas/templates/components/buttons/button-item-base.ts
+++ b/spec/components/schemas/templates/components/buttons/button-item-base.ts
@@ -7,7 +7,7 @@ const buttonItemBase: SchemaObject = {
     type: {
       title: 'Button type',
       enum: [
-        'URL', 'PHONE_NUMBER', 'QUICK_REPLY', 'OPT_OUT', 'MPM',
+        'URL', 'PHONE_NUMBER', 'QUICK_REPLY', 'OPT_OUT', 'MPM', 'COPY_CODE',
       ],
       type: 'string',
     },

--- a/spec/components/schemas/templates/components/buttons/button-item-coupon.ts
+++ b/spec/components/schemas/templates/components/buttons/button-item-coupon.ts
@@ -1,0 +1,14 @@
+// tslint:disable:max-line-length
+import { SchemaObject } from 'openapi3-ts';
+import { createComponentRef } from '../../../../../../utils/ref';
+import { ref as baseRef } from './button-item-base';
+
+const copyCodeButton: SchemaObject = {
+  type: 'object',
+  allOf: [{
+    $ref: baseRef,
+  }],
+};
+
+export const ref = createComponentRef(__filename);
+export default copyCodeButton;


### PR DESCRIPTION
**Dor:** Novo tipo de template Cupom será disponibilizado, para isso um novo tipo de botão foi criado dentro de Actions para que esse template seja enviado da maneira correta para o cliente final.

**O que foi feito:**

- Adicionado o botão bem como a descrição do campo obrigatório code em exemplos

**Resultados:**
![image](https://github.com/zenvia/zenvia-openapi-spec/assets/37602367/e01dfd44-667c-4b9b-a8f0-29024dcebb56)
![image](https://github.com/zenvia/zenvia-openapi-spec/assets/37602367/8fe78b2f-7de2-499f-8101-17ba2da5261b)

