### PR TITLE
Update on buttons quantities

### DIFF
--- a/spec/components/schemas/content/whatsapp/button/index.ts
+++ b/spec/components/schemas/content/whatsapp/button/index.ts
@@ -35,7 +35,7 @@ const button: SchemaObject = {
         type: 'array',
         title: 'List of buttons',
         minItems: 1,
-        maxItems: 3,
+        maxItems: 10,
         items: {
           type: 'object',
           properties: {

--- a/spec/components/schemas/templates/components/buttons/actions.ts
+++ b/spec/components/schemas/templates/components/buttons/actions.ts
@@ -16,8 +16,8 @@ const buttons: SchemaObject = {
     properties: {
       items: {
         title: 'Buttons',
-        description: 'List of buttons. Only one of the following can be included: URL, MPM, PHONE_NUMBER or COPY_CODE. MPM and COPY_CODE buttons are exclusively for use in [WHATSAPP](tag#WHATSAPP).',
-        maxItems: 3,
+        description: 'List of buttons. You can have two URL buttons and only one of the following can be included: MPM, PHONE_NUMBER or COPY_CODE. MPM and COPY_CODE buttons are exclusively for use in [WHATSAPP](tag#WHATSAPP).',
+        maxItems: 10,
         type: 'array',
         items: {
           type: 'object',

--- a/spec/components/schemas/templates/components/buttons/mixed.ts
+++ b/spec/components/schemas/templates/components/buttons/mixed.ts
@@ -15,8 +15,8 @@ const buttons: SchemaObject = {
     properties: {
       items: {
         title: 'Buttons',
-        description: 'List of buttons. Currently, only [RCS](#tag/RCS) channel is allowed. it is allowed to mix the 3 types of buttons, with a limit of up to 11 buttons.',
-        maxItems: 11,
+        description: 'List of buttons. It is allowed to mix the 3 types of buttons, with a limit of up to 10 buttons for the [WhatsApp](#tag/WhatsApp) channel',
+        maxItems: 10,
         type: 'array',
         items: {
           type: 'object',

--- a/spec/components/schemas/templates/components/buttons/quick-replies.ts
+++ b/spec/components/schemas/templates/components/buttons/quick-replies.ts
@@ -15,7 +15,7 @@ const buttons: SchemaObject = {
       items: {
         title: 'Buttons',
         description: 'List of buttons',
-        maxItems: 3,
+        maxItems: 10,
         type: 'array',
         items: {
           type: 'object',

--- a/spec/components/schemas/templates/components/buttons/rcs/mixed.ts
+++ b/spec/components/schemas/templates/components/buttons/rcs/mixed.ts
@@ -19,7 +19,7 @@ const buttons: SchemaObject = {
     properties: {
       items: {
         title: 'Buttons',
-        description: 'List of buttons. Currently, only [RCS](#tag/RCS) channel is allowed. It is possible to combine 3 types of buttons, with a limit of up to 11 buttons.',
+        description: 'List of buttons. Currently it is possible to combine 3 types of buttons, with a limit of up to 11 buttons for the [RCS](#tag/RCS) channel.',
         maxItems: 11,
         type: 'array',
         items: {


### PR DESCRIPTION
**Dor:** Devido à atualização da meta da quantidade de botões, surge a necessidade de atualizar as nossas regras de validação sobre a quantidade de botões permitidas.

**O que foi feito:**

- Alteradas a quantidade de botões possíveis para refletir a nova realidade

**Resultados:**

![image](https://github.com/zenvia/zenvia-openapi-spec/assets/37602367/d53dbfa6-4878-458a-a192-8496652d5020)
![image](https://github.com/zenvia/zenvia-openapi-spec/assets/37602367/d834f5f2-8225-4dbd-9780-08dbf4c82dc9)
