### PR TITLE
Add max length information

### DIFF
--- a/spec/components/schemas/content/bases/buttons/base.ts
+++ b/spec/components/schemas/content/bases/buttons/base.ts
@@ -11,7 +11,7 @@ const buttonBase: SchemaObject = {
     },
     text: {
       type: 'string',
-      description: 'Text to be displayed inside the button.',
+      description: 'Text to be displayed inside the button.<br><br>*[RCS](#tag/RCS): Maximum of 25 characters.*',
       example: 'Click me!',
     },
     payload: {

--- a/spec/info/description.md
+++ b/spec/info/description.md
@@ -44,7 +44,7 @@ You are allowed to send test messages to phone numbers you've connected during a
 
 All breaking changes to Zenvia APIs will be documented here.
 
-Currently, the Zenvia APIs is on version [v2](https://zenvia.github.io/zenvia-openapi-spec/v2/").
+Currently, the Zenvia APIs is on version [v2](https://zenvia.github.io/zenvia-openapi-spec/v2/).
 
 ## v2 (current)
 
@@ -55,7 +55,7 @@ Currently, the Zenvia APIs is on version [v2](https://zenvia.github.io/zenvia-op
 
 ## v1 (deprecated)
 
-You can still check v1 version clicking [here](https://zenvia.github.io/zenvia-openapi-spec/v1/").
+You can still check v1 version clicking [here](https://zenvia.github.io/zenvia-openapi-spec/v1/).
 
 # SDKs
 


### PR DESCRIPTION
Added text informing about the max size of text attribute for buttons (RCS)  


![image](https://github.com/zenvia/zenvia-openapi-spec/assets/13774879/70839a03-11e7-436b-a3a0-f8772084acc8)
