### PR TITLE
Feature/facebook template

### DIFF
--- a/spec/components/parameters/templates/channel.ts
+++ b/spec/components/parameters/templates/channel.ts
@@ -9,7 +9,7 @@ const channel: ParameterObject = {
   schema: {
     type: 'string',
     enum: [
-      'WHATSAPP', 'SMS', 'RCS', 'EMAIL',
+      'WHATSAPP', 'SMS', 'RCS', 'EMAIL', 'FACEBOOK',
     ],
   },
   example: 'WHATSAPP',

--- a/spec/components/schemas/content/facebook/mt.ts
+++ b/spec/components/schemas/content/facebook/mt.ts
@@ -6,6 +6,7 @@ import { ref as cardRef } from '../card';
 import { ref as carouselRef } from '../carousel';
 import { createComponentRef } from '../../../../../utils/ref';
 import { ref as optinRequestRef } from '../optin_request';
+import { ref as templateRef } from '../template';
 
 const all: SchemaObject = {
   title: 'Facebook',
@@ -13,6 +14,8 @@ const all: SchemaObject = {
     $ref: textRef,
   }, {
     $ref: fileRef,
+  },{
+    $ref: templateRef,
   }, {
     $ref: cardRef,
   }, {
@@ -27,6 +30,7 @@ const all: SchemaObject = {
     mapping: {
       text: textRef,
       file: fileRef,
+      template: templateRef,
       card: cardRef,
       carousel: carouselRef,
       replyable_text: quickRepliesRef,

--- a/spec/components/schemas/templates/category/facebook.ts
+++ b/spec/components/schemas/templates/category/facebook.ts
@@ -1,0 +1,18 @@
+// tslint:disable:max-line-length
+import { SchemaObject } from 'openapi3-ts';
+import { createComponentRef } from '../../../../../utils/ref';
+
+const category: SchemaObject = {
+  title: 'Category',
+  description: 'Category of use for this template',
+  type: 'string',
+  enum: [
+    'ACCOUNT_UPDATE',
+    'CUSTOMER_FEEDBACK',
+    'CONFIRMED_EVENT_UPDATE',
+    'POST_PURCHASE_UPDATE',
+  ],
+};
+
+export const ref = createComponentRef(__filename);
+export default category;

--- a/spec/components/schemas/templates/components/facebook.ts
+++ b/spec/components/schemas/templates/components/facebook.ts
@@ -1,0 +1,19 @@
+// tslint:disable:max-line-length
+import { SchemaObject } from 'openapi3-ts';
+import { createComponentRef } from '../../../../../utils/ref';
+import { ref as bodyRef } from './body';
+
+const facebookComponents: SchemaObject = {
+  title: 'Components',
+  description: 'Message content of this template',
+  type: 'object',
+  required: ['body'],
+  properties: {
+    body: {
+      $ref: bodyRef,
+    },
+  },
+};
+
+export const ref = createComponentRef(__filename);
+export default facebookComponents;

--- a/spec/components/schemas/templates/create/all.ts
+++ b/spec/components/schemas/templates/create/all.ts
@@ -3,6 +3,7 @@ import { ref as allWhatsContentsRef } from './whatsapp';
 import { ref as allSmsContentsRef } from './sms';
 import { ref as allRcsContentsRef } from './rcs';
 import { ref as allEmailContentsRef } from './email';
+import { ref as allFacebookContentsRef } from './facebook';
 import { createComponentRef } from '../../../../../utils/ref';
 
 const all: SchemaObject = {
@@ -10,6 +11,8 @@ const all: SchemaObject = {
     $ref: allWhatsContentsRef,
   },{
     $ref: allSmsContentsRef,
+  },{
+    $ref: allFacebookContentsRef,
   },{
     $ref: allRcsContentsRef,
   },{
@@ -22,6 +25,7 @@ const all: SchemaObject = {
       SMS: allSmsContentsRef,
       RCS: allRcsContentsRef,
       EMAIL: allEmailContentsRef,
+      FACEBOOK: allFacebookContentsRef,
     },
   },
 };

--- a/spec/components/schemas/templates/create/base.ts
+++ b/spec/components/schemas/templates/create/base.ts
@@ -23,7 +23,7 @@ const templateBase: SchemaObject = {
       title: 'Channel',
       description: 'Channel where the template will be made available.',
       type: 'string',
-      enum: ['WHATSAPP', 'SMS', 'RCS', 'EMAIL'],
+      enum: ['WHATSAPP', 'SMS', 'RCS', 'EMAIL', 'FACEBOOK'],
     },
     id: {
       title: 'Template ID',

--- a/spec/components/schemas/templates/create/facebook.ts
+++ b/spec/components/schemas/templates/create/facebook.ts
@@ -1,0 +1,26 @@
+import { SchemaObject } from 'openapi3-ts';
+import { ref as baseRef } from './base';
+import { createComponentRef } from '../../../../../utils/ref';
+import { ref as facebookTemplateCategoriesRef } from '../category/facebook';
+import { ref as facebookComponents } from '../components/facebook';
+
+const facebookTemplate: SchemaObject = {
+  type: 'object',
+  allOf: [{
+    type: 'object',
+    properties: {
+      components: {
+        $ref: facebookComponents,
+      },
+      category: {
+        $ref: facebookTemplateCategoriesRef,
+      },
+    },
+  }, {
+    $ref: baseRef,
+  }],
+
+};
+
+export const ref = createComponentRef(__filename);
+export default facebookTemplate;

--- a/spec/components/schemas/templates/template.ts
+++ b/spec/components/schemas/templates/template.ts
@@ -41,7 +41,7 @@ const template: SchemaObject = {
       title: 'Channel',
       description: 'Channel where the template will be made available.',
       type: 'string',
-      enum: ['WHATSAPP', 'SMS', 'RCS', 'EMAIL'],
+      enum: ['WHATSAPP', 'SMS', 'RCS', 'EMAIL', 'FACEBOOK'],
     },
     senderId: {
       title: 'Sender ID',

--- a/spec/paths/channels/channels@facebook@messages.ts
+++ b/spec/paths/channels/channels@facebook@messages.ts
@@ -8,6 +8,7 @@ import { card as cardExample } from '../../resources/examples/card';
 import { carousel as carouselExample } from '../../resources/examples/carousel';
 import { replyableText as replyableTextExample } from '../../resources/examples/replyable-text';
 import { optInRequest as optInRequestExample } from '../../resources/examples/optInRequest';
+import { template as templateExample } from '../../resources/examples/template';
 
 const post: OperationObject = {
   description: 'Send a Facebook message',
@@ -25,6 +26,9 @@ const post: OperationObject = {
           },
           file: {
             value: facebookExamples(fileExample()),
+          },
+          template: {
+            value: facebookExamples(templateExample()),
           },
           card: {
             value: facebookExamples(cardExample()),

--- a/test/contract/cases/channels/facebook/send-template.json
+++ b/test/contract/cases/channels/facebook/send-template.json
@@ -1,0 +1,45 @@
+{
+  "name": "send template content",
+  "request": {
+    "method": "POST",
+    "path": "/channels/facebook/messages",
+    "query": {
+    },
+    "headers": {
+      "content-type": "application/json",
+      "x-api-token": "some-api-token"
+    },
+    "body": {
+      "from": "SENDER ID",
+      "to": "RECIPIENT ID",
+      "contents": [{
+        "type": "template",
+        "templateId": "some template id",
+        "fields": {
+          "field1": "field1 value",
+          "field2": "field2 value"
+        }
+      }]
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "content-type": "application/json"
+    },
+    "body": {
+      "id": "CREATED MESSAGE ID",
+      "direction": "OUT",
+      "from": "SENDER ID",
+      "to": "RECIPIENT ID",
+      "contents": [{
+        "type": "template",
+        "templateId": "some template id",
+        "fields": {
+          "field1": "field1 value",
+          "field2": "field2 value"
+        }
+      }]
+    }
+  }
+}

--- a/test/contract/cases/templates/facebook/create.json
+++ b/test/contract/cases/templates/facebook/create.json
@@ -1,0 +1,47 @@
+{
+    "name": "create template with action buttons",
+    "request": {
+      "method": "POST",
+      "path": "/templates",
+      "query": {
+      },
+      "headers": {
+        "content-type": "application/json",
+        "x-api-token": "some-api-token"
+      },
+      "body": {
+        "name": "template name",
+        "locale": "pt_BR",
+        "channel": "FACEBOOK",
+        "senderId": "SENDER_ID",
+        "category": "ACCOUNT_UPDATE",
+        "components": {
+          "body": {
+            "type": "TEXT_FIXED",
+            "text": "some text"
+          }
+        }
+      }
+    },
+    "response": {
+      "status": 200,
+      "headers": {
+        "content-type": "application/json"
+      },
+      "body": {
+        "id": "UUID",
+        "name": "template name",
+        "locale": "pt_BR",
+        "channel": "FACEBOOK",
+        "senderId": "SENDER_ID",
+        "category": "ACCOUNT_UPDATE",
+        "components": {
+          "body": {
+            "type": "TEXT_FIXED",
+            "text": "some text"
+          }
+        }
+      }
+    }
+  }
+  

--- a/test/contract/contract.ts
+++ b/test/contract/contract.ts
@@ -80,6 +80,10 @@ describe('API contract test against OpenAPI specification', () => {
     loadTestCases('channels/whatsapp');
   });
 
+  describe('facebook messages', async () => {
+    loadTestCases('channels/facebook');
+  });
+
   describe('telegram messages', async () => {
     loadTestCases('channels/telegram');
   });


### PR DESCRIPTION
- Adição de facebook como opção de canal para criação de template:
![image](https://github.com/zenvia/zenvia-openapi-spec/assets/72479557/efef37e6-29c0-4e78-a0a5-e70667b58d47)
![image](https://github.com/zenvia/zenvia-openapi-spec/assets/72479557/e4427885-a63a-46fb-a4e6-bcc2539f2dc4)
![image](https://github.com/zenvia/zenvia-openapi-spec/assets/72479557/767d9428-8262-4f89-86f1-41514ed2e1fd)
![image](https://github.com/zenvia/zenvia-openapi-spec/assets/72479557/6997163d-01f4-40d9-997c-1a7bb87dccc5)

- Listagem:
![image](https://github.com/zenvia/zenvia-openapi-spec/assets/72479557/90369cdf-8201-4064-ba4c-bd31a5af0f4f)

- Adição de template como tipo de mensagem a ser enviada via facebook:
![image](https://github.com/zenvia/zenvia-openapi-spec/assets/72479557/a6ee4e94-bdf6-4d22-a630-ac42d88e053f)

