### PR TITLE
Added realChat Property to MSG_STATUS

### DIFF
--- a/spec/components/schemas/events/channel-data/index.ts
+++ b/spec/components/schemas/events/channel-data/index.ts
@@ -10,6 +10,21 @@ const channelData: SchemaObject = {
     sms: {
       $ref: smsRef,
     },
+    rcs: {
+      type: 'object',
+      title: 'RCS',
+      description: 'RCS specific details about the message',
+      properties: {
+        realChannel: {
+          title: 'Channel that sent the message on fallback.',
+          type: 'string',
+          enum: [
+            'SMS',
+            'RCS',
+          ],
+        },
+      },
+    },
   },
 };
 


### PR DESCRIPTION
Added new property to MESSAGE_STATUS.  

`realChannel` -> It will inform which channel actually sent the message when a fallback happens. (SMS or RCS)

![image](https://github.com/zenvia/zenvia-openapi-spec/assets/13774879/68d5ec14-00c8-4c2f-99d7-8fc2b5131524)

