### PR TITLE
Adding attributes to Webhook Status

### DIFF
--- a/spec/components/schemas/events/message-status-event.ts
+++ b/spec/components/schemas/events/message-status-event.ts
@@ -20,9 +20,24 @@ const messageEvent: SchemaObject = {
         ],
         example: 'MESSAGE_STATUS',
       },
+      from: {
+        type: 'string',
+        description: 'Contact of origin',
+        example: 'email@email.com',
+      },
+      to: {
+        type: 'string',
+        description: 'Recipient contact',
+        example: 'received_email@email.com',
+      },
       messageId: {
         title: 'Message ID',
         description: 'ID of the message whose status is being delivered',
+        type: 'string',
+      },
+      externalId: {
+        title: 'Message External ID',
+        description: 'A customizable identifier for dispatches, allowing users to customize and track their dispatches within the API',
         type: 'string',
       },
       contentIndex: {

--- a/spec/components/schemas/events/message-status-event.ts
+++ b/spec/components/schemas/events/message-status-event.ts
@@ -20,30 +20,44 @@ const messageEvent: SchemaObject = {
         ],
         example: 'MESSAGE_STATUS',
       },
-      from: {
-        type: 'string',
-        description: 'Contact of origin',
-        example: 'email@email.com',
-      },
-      to: {
-        type: 'string',
-        description: 'Recipient contact',
-        example: 'received_email@email.com',
-      },
       messageId: {
         title: 'Message ID',
-        description: 'ID of the message whose status is being delivered',
-        type: 'string',
-      },
-      externalId: {
-        title: 'Message External ID',
-        description: 'A customizable identifier for dispatches, allowing users to customize and track their dispatches within the API',
+        description: 'ID of the message whose status is being delivered (deprecated)',
         type: 'string',
       },
       contentIndex: {
         title: 'Content Index',
-        description: 'Index of content that is receiving the status update',
+        description: 'Index of content that is receiving the status update (deprecated)',
         type: 'number',
+      },
+      message: {
+        properties: {
+          id: {
+            title: 'Message ID',
+            description: 'ID of the message whose status is being delivered',
+            type: 'string',
+          },
+          externalId: {
+            title: 'Message External ID',
+            description: 'A customizable identifier for dispatches, allowing users to customize and track their dispatches within the API',
+            type: 'string',
+          },
+          contentIndex: {
+            title: 'Content Index',
+            description: 'Index of content that is receiving the status update',
+            type: 'number',
+          },
+          from: {
+            type: 'string',
+            description: 'Contact of origin',
+            example: 'email@email.com',
+          },
+          to: {
+            type: 'string',
+            description: 'Recipient contact',
+            example: 'received_email@email.com',
+          },
+        },
       },
       messageStatus: {
         $ref: messageStatusRef,

--- a/spec/components/schemas/events/message-status-event.ts
+++ b/spec/components/schemas/events/message-status-event.ts
@@ -22,13 +22,15 @@ const messageEvent: SchemaObject = {
       },
       messageId: {
         title: 'Message ID',
-        description: 'ID of the message whose status is being delivered (deprecated)',
+        description: 'ID of the message whose status is being delivered',
         type: 'string',
+        deprecated: true,
       },
       contentIndex: {
         title: 'Content Index',
-        description: 'Index of content that is receiving the status update (deprecated)',
+        description: 'Index of content that is receiving the status update',
         type: 'number',
+        deprecated: true,
       },
       message: {
         properties: {

--- a/spec/components/schemas/message/base.ts
+++ b/spec/components/schemas/message/base.ts
@@ -13,6 +13,11 @@ const base: SchemaObject = {
       type: 'string',
       readOnly: true,
     },
+    externalId: {
+      title: 'Message External ID',
+      description: 'A customizable identifier for dispatches, allowing users to customize and track their dispatches within the API',
+      type: 'string',
+    },
     from: {
       title: 'Sender ID',
       description: `The identifier of the sender of the message. The sender is created when an integration for the channel is connected

--- a/spec/resources/examples/text.ts
+++ b/spec/resources/examples/text.ts
@@ -1,5 +1,6 @@
 export function text() {
   return {
+    externalId: 'my-campaign-name',
     from: '5510999999999',
     to: '55108888888888',
     contents: [{


### PR DESCRIPTION
Encapsulate data from `message entity` within an object called `message`.

Final result:
```
{
  "id": "string",
  "timestamp": "2019-08-24T14:15:22Z",
  "type": "MESSAGE_STATUS",
  "subscriptionId": "string",
  "channel": "string",
  "messageId": "string",
  "contentIndex": 0,
  "message": {
    "id": "string",
    "externalId": "string",
    "contentIndex": 0,
    "from": "email@email.com",
    "to": "received_email@email.com"
  },
  "messageStatus": {...}
}
```