### PR TITLE
Modifying subscription status enum for new update rules by API

### DIFF
--- a/spec/components/schemas/subscription/partial-status/all.ts
+++ b/spec/components/schemas/subscription/partial-status/all.ts
@@ -1,0 +1,22 @@
+import { SchemaObject } from 'openapi3-ts';
+import { createComponentRef } from '../../../../../utils/ref';
+import { ref as messageSubscriptionRef } from './message-subscription';
+import { ref as messageStatusSubscriptionRef } from './message-status-subscription';
+
+const all: SchemaObject = {
+  oneOf: [{
+    $ref: messageSubscriptionRef,
+  }, {
+    $ref: messageStatusSubscriptionRef,
+  }],
+  discriminator: {
+    propertyName: 'eventType',
+    mapping: {
+      MESSAGE: messageSubscriptionRef,
+      MESSAGE_STATUS: messageStatusSubscriptionRef,
+    },
+  },
+};
+
+export const ref = createComponentRef(__filename);
+export default all;

--- a/spec/components/schemas/subscription/partial-status/base.ts
+++ b/spec/components/schemas/subscription/partial-status/base.ts
@@ -1,0 +1,62 @@
+import { SchemaObject } from 'openapi3-ts';
+import { createComponentRef } from '../../../../../utils/ref';
+import { ref as webhookSchemaRef } from './webhook';
+import { ref as statusRef } from './status';
+
+const subscriptionBase: SchemaObject = {
+  type: 'object',
+  properties: {
+    id: {
+      title: 'Subscription Id',
+      type: 'string',
+      readOnly: true,
+    },
+    eventType: {
+      title: 'Event type to subscribe',
+      type: 'string',
+      enum: [
+        'MESSAGE',
+        'MESSAGE_STATUS',
+      ],
+    },
+    webhook: {
+      allOf: [{
+        $ref: webhookSchemaRef,
+      }, {
+        type: 'object',
+        required: ['url'],
+      }],
+    },
+    status: {
+      $ref: statusRef,
+    },
+    version: {
+      title: 'Version of subscription',
+      type: 'string',
+      enum: [
+        'v1',
+        'v2',
+      ],
+      default: 'v2',
+    },
+    createdAt: {
+      title: 'Creation timestamp',
+      description: 'Creation timestamp in ISO format',
+      type: 'string',
+      readOnly: true,
+    },
+    updatedAt: {
+      title: 'Update timestamp',
+      description: 'Update timestamp in ISO format',
+      type: 'string',
+      readOnly: true,
+    },
+  },
+  required: [
+    'eventType',
+    'webhook',
+  ],
+};
+
+export const ref = createComponentRef(__filename);
+export default subscriptionBase;

--- a/spec/components/schemas/subscription/partial-status/message-status-subscription.ts
+++ b/spec/components/schemas/subscription/partial-status/message-status-subscription.ts
@@ -1,0 +1,29 @@
+// tslint:disable:max-line-length
+import { SchemaObject } from 'openapi3-ts';
+import { ref as baseRef } from './base';
+import { ref as channelRef } from '../../message/channel';
+import { createComponentRef } from '../../../../../utils/ref';
+
+const subscription: SchemaObject = {
+  type: 'object',
+  allOf: [{
+    $ref: baseRef,
+  }, {
+    type: 'object',
+    properties: {
+      criteria: {
+        type: 'object',
+        properties: {
+          channel: {
+            $ref: channelRef,
+          },
+        },
+        required: ['channel'],
+      },
+    },
+    required: ['criteria'],
+  }],
+};
+
+export const ref = createComponentRef(__filename);
+export default subscription;

--- a/spec/components/schemas/subscription/partial-status/message-subscription.ts
+++ b/spec/components/schemas/subscription/partial-status/message-subscription.ts
@@ -1,0 +1,38 @@
+// tslint:disable:max-line-length
+import { SchemaObject } from 'openapi3-ts';
+import { ref as baseRef } from './base';
+import { ref as channelRef } from '../../message/channel';
+import { createComponentRef } from '../../../../../utils/ref';
+
+const subscription: SchemaObject = {
+  type: 'object',
+  allOf: [{
+    $ref: baseRef,
+  }, {
+    type: 'object',
+    properties: {
+      criteria: {
+        type: 'object',
+        properties: {
+          channel: {
+            $ref: channelRef,
+          },
+          direction: {
+            title: 'Message direction',
+            description: 'Indicates whether the message is received from a channel (IN) or sent to a channel (OUT)',
+            type: 'string',
+            enum: [
+              'IN',
+              'OUT',
+            ],
+          },
+        },
+        required: ['channel'],
+      },
+    },
+    required: ['criteria'],
+  }],
+};
+
+export const ref = createComponentRef(__filename);
+export default subscription;

--- a/spec/components/schemas/subscription/partial-status/status.ts
+++ b/spec/components/schemas/subscription/partial-status/status.ts
@@ -1,0 +1,15 @@
+// tslint:disable:max-line-length
+import { SchemaObject } from 'openapi3-ts';
+import { createComponentRef } from '../../../../../utils/ref';
+
+const status: SchemaObject = {
+  title: 'Status of subscription',
+  type: 'string',
+  enum: [
+    'ACTIVE',
+    'INACTIVE',
+  ],
+};
+
+export const ref = createComponentRef(__filename);
+export default status;

--- a/spec/components/schemas/subscription/partial-status/webhook.ts
+++ b/spec/components/schemas/subscription/partial-status/webhook.ts
@@ -1,0 +1,20 @@
+import { SchemaObject } from 'openapi3-ts';
+import { createComponentRef } from '../../../../../utils/ref';
+
+const subscription: SchemaObject = {
+  type: 'object',
+  properties: {
+    url: {
+      title: 'Webhook URL',
+      description: 'URL to post events',
+      type: 'string',
+    },
+    headers: {
+      title: 'Request headers',
+      type: 'object',
+    },
+  },
+};
+
+export const ref = createComponentRef(__filename);
+export default subscription;

--- a/spec/components/schemas/subscription/partial-subscription.ts
+++ b/spec/components/schemas/subscription/partial-subscription.ts
@@ -1,7 +1,7 @@
 import { SchemaObject } from 'openapi3-ts';
 import { createComponentRef } from '../../../../utils/ref';
 import { ref as webhookSchemaRef } from './webhook';
-import { ref as statusRef } from './status';
+import { ref as statusRef } from './partial-status/status';
 
 const partialSubscription: SchemaObject = {
   type: 'object',

--- a/spec/paths/subscriptions/subscriptions.ts
+++ b/spec/paths/subscriptions/subscriptions.ts
@@ -6,6 +6,7 @@ import {
   ResponsesObject,
 } from 'openapi3-ts';
 import { ref as subscriptionSchemaRef } from '../../components/schemas/subscription/all';
+import { ref as subscriptionPartialStatusSchemaRef } from '../../components/schemas/subscription/partial-status/all';
 import { ref as notificationCallbackRef } from '../../components/callbacks/subscription-event';
 import { ref as errorResponseRef } from '../../components/responses/error';
 
@@ -18,7 +19,7 @@ const post: OperationObject = {
       content: {
         'application/json': {
           schema: {
-            $ref: subscriptionSchemaRef,
+            $ref: subscriptionPartialStatusSchemaRef,
           },
         },
       },
@@ -31,7 +32,7 @@ const post: OperationObject = {
     content: {
       'application/json': {
         schema: {
-          $ref: subscriptionSchemaRef,
+          $ref: subscriptionPartialStatusSchemaRef,
         },
       },
     },

--- a/spec/tags/subscriptions.md
+++ b/spec/tags/subscriptions.md
@@ -90,8 +90,8 @@ The criteria which trigger status changes consist of the following:
 * 50 consecutive successful requests on a *DEGRADED* webhook are necessary for promotion back to *ACTIVE*
   * Successful requests on retry attempts also count toward status promotion
   * Responses slower than *1 second* do not count either as a success or as a fail
-* Any manual update done to the webhook on the [API console](https://app.zenvia.com/home/api) will automatically
-promote either a *DEGRADED* or an *INACTIVE* webhook back to *ACTIVE*.
+* Any manual update done to the webhook URL on the [API console](https://app.zenvia.com/home/api) will automatically
+promote either a *DEGRADED* webhook back to *ACTIVE*.
 
 Both the success and fail counters automatically reset themselves *8 hours* after the first increment.
 

--- a/spec/tags/subscriptions.md
+++ b/spec/tags/subscriptions.md
@@ -91,7 +91,7 @@ The criteria which trigger status changes consist of the following:
   * Successful requests on retry attempts also count toward status promotion
   * Responses slower than *1 second* do not count either as a success or as a fail
 * Any manual update done to the webhook URL on the [API console](https://app.zenvia.com/home/api) will automatically
-promote either a *DEGRADED* webhook back to *ACTIVE*.
+promote a *DEGRADED* webhook back to *ACTIVE*.
 
 Both the success and fail counters automatically reset themselves *8 hours* after the first increment.
 


### PR DESCRIPTION
Users of the API are no longer allowed to change the status of their webhooks from DEGRADED to ACTIVE.  

Therefore, in the PATCH and POST methods, the status DEGRADED will no longer be shown as an option in the enum:

![image](https://github.com/user-attachments/assets/d67755b1-a08f-4301-bd70-6e7b8701c470)
![image](https://github.com/user-attachments/assets/eec2664d-7e33-4d03-8a16-5ebf1922c995)

For the GET and GET BY ID methods, the status DEGRADED will still remain to correctly inform the user of the webhook's status:
![image](https://github.com/user-attachments/assets/b1d5add8-376e-4bd9-af76-18b8aa2027f6)
![image](https://github.com/user-attachments/assets/aa66d2ae-c9fe-4db5-8aa5-593cccb524b4)

The text was also modified to explain that the status of a webhook will only change from DEGRADED after a URL update:
![image](https://github.com/user-attachments/assets/111fb4d3-5460-46b1-9b9a-21dc2811c50d)
