### PR TITLE
CON-2023

### DIFF
--- a/spec/components/schemas/2fa/token/requests/recipient.ts
+++ b/spec/components/schemas/2fa/token/requests/recipient.ts
@@ -16,7 +16,7 @@ const verification: SchemaObject = {
     },
     code: {
       type: 'string',
-      description: 'Code sended by the user',
+      description: 'Code sent by the user',
       example: '269878',
     },
   },

--- a/spec/components/schemas/2fa/token/responses/token-verified.ts
+++ b/spec/components/schemas/2fa/token/responses/token-verified.ts
@@ -32,11 +32,6 @@ const tokenVerified: SchemaObject = {
       description: 'Location configured',
       example: 'pt_br',
     },
-    code: {
-      type: 'string',
-      description: 'The code generated',
-      example: '100569',
-    },
     configurationId: {
       type: 'string',
       description: 'Token Configuration Id',

--- a/spec/components/schemas/2fa/token/responses/token.ts
+++ b/spec/components/schemas/2fa/token/responses/token.ts
@@ -32,11 +32,6 @@ const sendToken: SchemaObject = {
       description: 'Configured locale',
       example: 'pt_br',
     },
-    code: {
-      type: 'string',
-      description: 'The generated token',
-      example: '100569',
-    },
     configurationId: {
       type: 'string',
       description: 'Token Configuration Id',

--- a/spec/tags/2fa.md
+++ b/spec/tags/2fa.md
@@ -18,16 +18,9 @@ Our 2FA service ensures that access requests are made by trusted users by identi
 - **SMS**
 - **Email**
 
-### Remote IP Address Verification
-
-When verifying tokens, it is essential to ensure that both the original IP address from which the token was sent and the remote IP address from which the verification request originates are the same. This means that the request to create or send the token must match the request used for verification, ensuring that only authorized users can access your system.
-
 ### How it Works
 
 Here's how our 2FA service works:
 
-1. The user requests a token, and we generate a unique token for them.
-2. When verifying the token, we check that the IP address from which the request was made matches the original IP address of the token creation request.
-3. If the IP addresses match, we allow access to your system.
-
-By ensuring that the IP address of the token creation request is the same as the IP address of the token verification request, we can prevent unauthorized access attempts and maintain the integrity of our 2FA system.
+1. The user requests a token and we generate a unique token for them.
+2. Upon verification of said token we ensure that the generated one and the incoming one match, and only then we allow access to your system.


### PR DESCRIPTION
Removed a requisite for 2FA. No longer the IP address that was responsible for requesting the creation of a token has to be the one that verifies it.