### PR TITLE
WHAT-3971

### DIFF
--- a/spec/components/schemas/content/template.ts
+++ b/spec/components/schemas/content/template.ts
@@ -32,27 +32,55 @@ const template: SchemaObject = {
         oneOf: [
           {
             title: 'Cards',
-            additionalProperties: false,
             required: ['cards'],
+            additionalProperties: {
+              description: 'Value provided to fill the variable named after the property name.',
+              oneOf: [{
+                type: 'string',
+                example: 'Zenvia',
+              }, {
+                type: 'number',
+                example: 1,
+              }, {
+                type: 'boolean',
+                example: true,
+              }],
+            },
             properties: {
               cards: {
                 type: 'array',
-                description: 'The properties of the cards in a template. Only applicable to [WhatsApp](#tag/WhatsApp) channel.',
+                description: 'The properties of the cards in a template.\nIn cards with a predefined order, each card will be rendered following its order at the time of the creation of the template.\n\n Only applicable to [WhatsApp](#tag/WhatsApp) channel.',
                 minItems: 2,
                 maxItems: 10,
                 items: {
                   type: 'object',
-                  required: ['orderPosition', 'imageUrl'],
-                  properties: {
-                    orderPosition: {
-                      description: 'Defines the final position of the card in the outcome. The array index indicates which card is being referenced, and the value of `orderPosition` determines its final position.',
-                      type: 'number',
+                  oneOf: [
+                    {
+                      title: 'Cards with dynamic ordering',
+                      required: ['orderPosition', 'imageUrl'],
+                      properties: {
+                        orderPosition: {
+                          description: 'Defines the final position of the card in the outcome. The array index indicates which card is being referenced, and the value of `orderPosition` determines its final position.',
+                          type: 'number',
+                        },
+                        imageUrl: {
+                          type: 'string',
+                          description: 'URL of the image',
+                        },
+                      },
                     },
-                    imageUrl: {
-                      type: 'string',
-                      description: 'URL of the image',
+                    {
+                      title: 'Cards with predefined order',
+                      required: ['imageUrl'],
+                      additionalProperties: false,
+                      properties: {
+                        imageUrl: {
+                          type: 'string',
+                          description: 'URL of the image',
+                        },
+                      },
                     },
-                  },
+                  ],
                 },
               },
             },

--- a/spec/components/schemas/content/template.ts
+++ b/spec/components/schemas/content/template.ts
@@ -42,6 +42,7 @@ const template: SchemaObject = {
                 maxItems: 10,
                 items: {
                   type: 'object',
+                  required: ['orderPosition', 'imageUrl'],
                   properties: {
                     orderPosition: {
                       description: 'Defines the final position of the card in the outcome. The array index indicates which card is being referenced, and the value of `orderPosition` determines its final position.',
@@ -52,30 +53,27 @@ const template: SchemaObject = {
                       description: 'URL of the image',
                     },
                   },
-                  required: ['orderPosition', 'imageUrl'],
                 },
               },
             },
           },
           {
             title: 'Product Sections',
-            additionalProperties: false,
-            required: ['sections'],
+            additionalProperties: {
+              description: 'Value provided to fill the variable named after the property name.',
+              oneOf: [{
+                type: 'string',
+                example: 'Zenvia',
+              }, {
+                type: 'number',
+                example: 1,
+              }, {
+                type: 'boolean',
+                example: true,
+              }],
+            },
             properties: {
               sections: { $ref: productSections },
-              additionalProperties: {
-                description: 'Value provided to fill the variable named after the property name.',
-                oneOf: [{
-                  type: 'string',
-                  example: 'Zenvia',
-                }, {
-                  type: 'number',
-                  example: 1,
-                }, {
-                  type: 'boolean',
-                  example: true,
-                }],
-              },
             },
           },
         ],

--- a/spec/components/schemas/content/template.ts
+++ b/spec/components/schemas/content/template.ts
@@ -29,22 +29,56 @@ const template: SchemaObject = {
           user: 'John Smith',
           protocol: '34534252',
         },
-        properties: {
-          sections: { $ref: productSections },
-        },
-        additionalProperties: {
-          description: 'Value provided to fill the variable named after the property name.',
-          oneOf: [{
-            type: 'string',
-            example: 'Zenvia',
-          }, {
-            type: 'number',
-            example: 1,
-          }, {
-            type: 'boolean',
-            example: true,
-          }],
-        },
+        oneOf: [
+          {
+            title: 'Cards',
+            additionalProperties: false,
+            required: ['cards'],
+            properties: {
+              cards: {
+                type: 'array',
+                description: 'The properties of the cards in a template. Only applicable to [WhatsApp](#tag/WhatsApp) channel.',
+                minItems: 2,
+                maxItems: 10,
+                items: {
+                  type: 'object',
+                  properties: {
+                    orderPosition: {
+                      description: 'Defines the final position of the card in the outcome. The array index indicates which card is being referenced, and the value of `orderPosition` determines its final position.',
+                      type: 'number',
+                    },
+                    imageUrl: {
+                      type: 'string',
+                      description: 'URL of the image',
+                    },
+                  },
+                  required: ['orderPosition', 'imageUrl'],
+                },
+              },
+            },
+          },
+          {
+            title: 'Product Sections',
+            additionalProperties: false,
+            required: ['sections'],
+            properties: {
+              sections: { $ref: productSections },
+              additionalProperties: {
+                description: 'Value provided to fill the variable named after the property name.',
+                oneOf: [{
+                  type: 'string',
+                  example: 'Zenvia',
+                }, {
+                  type: 'number',
+                  example: 1,
+                }, {
+                  type: 'boolean',
+                  example: true,
+                }],
+              },
+            },
+          },
+        ],
       },
     },
     required: [

--- a/spec/components/schemas/templates/components/card/index.ts
+++ b/spec/components/schemas/templates/components/card/index.ts
@@ -1,0 +1,7 @@
+import { SchemaObject } from 'openapi3-ts';
+import { createComponentRef } from '../../../../../../utils/ref';
+
+const card: SchemaObject = {};
+
+export const ref = createComponentRef(__filename);
+export default card;

--- a/spec/components/schemas/templates/components/card/index.ts
+++ b/spec/components/schemas/templates/components/card/index.ts
@@ -1,7 +1,0 @@
-import { SchemaObject } from 'openapi3-ts';
-import { createComponentRef } from '../../../../../../utils/ref';
-
-const card: SchemaObject = {};
-
-export const ref = createComponentRef(__filename);
-export default card;

--- a/spec/components/schemas/templates/components/carousel/buttons/actions.ts
+++ b/spec/components/schemas/templates/components/carousel/buttons/actions.ts
@@ -1,0 +1,48 @@
+// tslint:disable:max-line-length
+import { SchemaObject } from 'openapi3-ts';
+import { createComponentRef } from '../../../../../../../utils/ref';
+import { ref as baseRef } from './base';
+import { ref as urlRef } from './button-item-url';
+import { ref as phoneNumberRef } from './button-item-phone-number';
+
+const buttons: SchemaObject = {
+  type: 'object',
+  allOf: [{
+    $ref: baseRef,
+  }, {
+    type: 'object',
+    properties: {
+      items: {
+        title: 'Buttons',
+        description: 'List of buttons. You can have two URL buttons and only one  PHONE_NUMBER button.',
+        minItems: 1,
+        maxItems: 2,
+        type: 'array',
+        items: {
+          type: 'object',
+          oneOf: [{
+            $ref: urlRef,
+          }, {
+            $ref: phoneNumberRef,
+          }],
+          required: [
+            'type',
+          ],
+          discriminator: {
+            propertyName: 'type',
+            mapping: {
+              URL: urlRef,
+              PHONE_NUMBER: phoneNumberRef,
+            },
+          },
+        },
+      },
+    },
+    required: [
+      'items',
+    ],
+  }],
+};
+
+export const ref = createComponentRef(__filename);
+export default buttons;

--- a/spec/components/schemas/templates/components/carousel/buttons/base.ts
+++ b/spec/components/schemas/templates/components/carousel/buttons/base.ts
@@ -1,0 +1,18 @@
+import { SchemaObject } from 'openapi3-ts';
+import { createComponentRef } from '../../../../../../../utils/ref';
+
+const contentBase: SchemaObject = {
+  type: 'object',
+  properties: {
+    type: {
+      title: 'Content type',
+      type: 'string',
+    },
+  },
+  required: [
+    'type',
+  ],
+};
+
+export const ref = createComponentRef(__filename);
+export default contentBase;

--- a/spec/components/schemas/templates/components/carousel/buttons/button-item-base.ts
+++ b/spec/components/schemas/templates/components/carousel/buttons/button-item-base.ts
@@ -1,0 +1,21 @@
+import { SchemaObject } from 'openapi3-ts';
+import { createComponentRef } from '../../../../../../../utils/ref';
+
+const buttonItemBase: SchemaObject = {
+  type: 'object',
+  properties: {
+    type: {
+      title: 'Button type',
+      enum: [
+        'URL', 'PHONE_NUMBER', 'QUICK_REPLY', 'OPT_OUT', 'MPM', 'COPY_CODE', 'VIEW_LOCATION', 'SEARCH_LOCATION', 'SHARE_LOCATION', 'CALENDAR_EVENT',
+      ],
+      type: 'string',
+    },
+  },
+  required: [
+    'type',
+  ],
+};
+
+export const ref = createComponentRef(__filename);
+export default buttonItemBase;

--- a/spec/components/schemas/templates/components/carousel/buttons/button-item-phone-number.ts
+++ b/spec/components/schemas/templates/components/carousel/buttons/button-item-phone-number.ts
@@ -1,0 +1,30 @@
+// tslint:disable:max-line-length
+import { SchemaObject } from 'openapi3-ts';
+import { createComponentRef } from '../../../../../../../utils/ref';
+import { ref as baseRef } from './button-item-base';
+import { ref as btnTextRef } from './button-item-text';
+
+const phoneNumberButton: SchemaObject = {
+  type: 'object',
+  allOf: [
+    { $ref: baseRef },
+    { $ref: btnTextRef },
+    {
+    type: 'object',
+    properties: {
+      phoneNumber: {
+        title: 'Phone number of button',
+        description: 'Phone number to be sent in the button',
+        type: 'string',
+      },
+    },
+    required: [
+      'type',
+      'text',
+      'phoneNumber',
+    ],
+  }],
+};
+
+export const ref = createComponentRef(__filename);
+export default phoneNumberButton;

--- a/spec/components/schemas/templates/components/carousel/buttons/button-item-quick-reply.ts
+++ b/spec/components/schemas/templates/components/carousel/buttons/button-item-quick-reply.ts
@@ -1,0 +1,30 @@
+// tslint:disable:max-line-length
+import { SchemaObject } from 'openapi3-ts';
+import { createComponentRef } from '../../../../../../../utils/ref';
+import { ref as baseRef } from './button-item-base';
+import { ref as btnTextRef } from './button-item-text';
+
+const quickReplyButton: SchemaObject = {
+  type: 'object',
+  allOf: [
+    { $ref: baseRef },
+    { $ref: btnTextRef },
+    {
+    type: 'object',
+    properties: {
+      payload: {
+        type: 'string',
+        title: 'Payload of button',
+        description: 'This payload is used for identify the click in the callback',
+      },
+    },
+    required: [
+      'type',
+      'text',
+      'payload',
+    ],
+  }],
+};
+
+export const ref = createComponentRef(__filename);
+export default quickReplyButton;

--- a/spec/components/schemas/templates/components/carousel/buttons/button-item-text.ts
+++ b/spec/components/schemas/templates/components/carousel/buttons/button-item-text.ts
@@ -1,0 +1,18 @@
+import { SchemaObject } from 'openapi3-ts';
+import { createComponentRef } from '../../../../../../../utils/ref';
+
+const buttonItemBase: SchemaObject = {
+  type: 'object',
+  properties: {
+    text: {
+      title: 'Button text',
+      type: 'string',
+    },
+  },
+  required: [
+    'text',
+  ],
+};
+
+export const ref = createComponentRef(__filename);
+export default buttonItemBase;

--- a/spec/components/schemas/templates/components/carousel/buttons/button-item-url.ts
+++ b/spec/components/schemas/templates/components/carousel/buttons/button-item-url.ts
@@ -1,0 +1,31 @@
+// tslint:disable:max-line-length
+import { SchemaObject } from 'openapi3-ts';
+import { createComponentRef } from '../../../../../../../utils/ref';
+import { ref as baseRef } from './button-item-base';
+import { ref as btnTextRef } from './button-item-text';
+
+const urlButton: SchemaObject = {
+  type: 'object',
+  allOf: [
+    { $ref: baseRef },
+    { $ref: btnTextRef },
+    {
+      type: 'object',
+      properties: {
+        url: {
+          title: 'URL of button',
+          description: 'URL to be sent in the button. It can be dynamic',
+          type: 'string',
+        },
+      },
+      required: [
+        'type',
+        'text',
+        'url',
+      ],
+    },
+  ],
+};
+
+export const ref = createComponentRef(__filename);
+export default urlButton;

--- a/spec/components/schemas/templates/components/carousel/buttons/mixed.ts
+++ b/spec/components/schemas/templates/components/carousel/buttons/mixed.ts
@@ -1,0 +1,50 @@
+// tslint:disable:max-line-length
+import { SchemaObject } from 'openapi3-ts';
+import { createComponentRef } from '../../../../../../../utils/ref';
+import { ref as baseRef } from './base';
+import { ref as urlRef } from './button-item-url';
+import { ref as phoneNumberRef } from './button-item-phone-number';
+import { ref as quickReplyRef } from './button-item-quick-reply';
+
+const buttons: SchemaObject = {
+  type: 'object',
+  allOf: [{
+    $ref: baseRef,
+  }, {
+    type: 'object',
+    properties: {
+      items: {
+        title: 'Buttons',
+        description: 'List of buttons. It is allowed to mix the 3 types of buttons.',
+        minItems: 1,
+        maxItems: 2,
+        type: 'array',
+        items: {
+          type: 'object',
+          oneOf: [
+            { $ref: phoneNumberRef },
+            { $ref: quickReplyRef },
+            { $ref: urlRef },
+          ],
+          required: [
+            'type',
+          ],
+          discriminator: {
+            propertyName: 'type',
+            mapping: {
+              PHONE_NUMBER: phoneNumberRef,
+              QUICK_REPLY: quickReplyRef,
+              URL: urlRef,
+            },
+          },
+        },
+      },
+    },
+    required: [
+      'items',
+    ],
+  }],
+};
+
+export const ref = createComponentRef(__filename);
+export default buttons;

--- a/spec/components/schemas/templates/components/carousel/buttons/quick-replies.ts
+++ b/spec/components/schemas/templates/components/carousel/buttons/quick-replies.ts
@@ -1,0 +1,44 @@
+// tslint:disable:max-line-length
+import { SchemaObject } from 'openapi3-ts';
+import { createComponentRef } from '../../../../../../../utils/ref';
+import { ref as baseRef } from './base';
+import { ref as quickReplyRef } from './button-item-quick-reply';
+
+const buttons: SchemaObject = {
+  type: 'object',
+  allOf: [{
+    $ref: baseRef,
+  }, {
+    type: 'object',
+    properties: {
+      items: {
+        title: 'Buttons',
+        description: 'List of buttons',
+        minItems: 1,
+        maxItems: 2,
+        type: 'array',
+        items: {
+          type: 'object',
+          oneOf: [{
+            $ref: quickReplyRef,
+          }],
+          required: [
+            'type',
+          ],
+          discriminator: {
+            propertyName: 'type',
+            mapping: {
+              QUICK_REPLY: quickReplyRef,
+            },
+          },
+        },
+      },
+    },
+    required: [
+      'items',
+    ],
+  }],
+};
+
+export const ref = createComponentRef(__filename);
+export default buttons;

--- a/spec/components/schemas/templates/components/carousel/index.ts
+++ b/spec/components/schemas/templates/components/carousel/index.ts
@@ -1,0 +1,26 @@
+import { SchemaObject } from 'openapi3-ts';
+import { createComponentRef } from '../../../../../../utils/ref';
+import { ref as cardRef } from '../card';
+
+const carousel: SchemaObject = {
+  title: 'Carousel',
+  description: '',
+  type: 'object',
+  required: [],
+  properties: {
+    type: {
+      title: 'Cards type',
+      description: 'The cards can beither fixed or unordered. An order for the unordered cards is selected on dispatch for that carousel template.',
+      type: 'string',
+      enum: ['CARD_FIXED','CARD_TEMPLATE'],
+    },
+    cards: {
+      allOf: [{
+        $ref: cardRef,
+      }],
+    }
+  },
+};
+
+export const ref = createComponentRef(__filename);
+export default carousel;

--- a/spec/components/schemas/templates/components/carousel/index.ts
+++ b/spec/components/schemas/templates/components/carousel/index.ts
@@ -14,7 +14,7 @@ const carousel: SchemaObject = {
   properties: {
     type: {
       title: 'Cards type',
-      description: 'The cards can beither fixed or unordered. An order for the unordered cards is defined upon dispatch of the template.',
+      description: 'The cards can either have their position fixed or defined upon dispatch.',
       type: 'string',
       enum: ['CARD_FIXED','CARD_TEMPLATE'],
     },
@@ -58,31 +58,22 @@ const carousel: SchemaObject = {
           },
           buttons: {
             title: 'Card buttons',
-            description: 'Where one or two buttons of type URL, Quick Reply or Phone Number shall be included',
-            properties: {
-              type: {
-                type: 'string',
-                description: 'Button types',
-                example: 'QUICK_REPLIES',
-              },
-              items: {
-                type: 'array',
-                minItems: 1,
-                maxItems: 2,
-                items: {
-                  oneOf: [
-                    { $ref: buttonURLRef },
-                    { $ref: buttonPhoneNumberRef },
-                    { $ref: buttonQuickReplyRef },
-                  ],
-                  discriminator: {
-                    propertyName: 'type',
-                    mapping: {
-                      URL: buttonURLRef,
-                      PHONE_NUMBER: buttonPhoneNumberRef,
-                      QUICK_REPLY: buttonQuickReplyRef,
-                    },
-                  },
+            description: 'Buttons of type URL, Quick Reply and Phone Number',
+            type: 'array',
+            minItems: 1,
+            maxItems: 2,
+            items: {
+              oneOf: [
+                { $ref: buttonURLRef },
+                { $ref: buttonPhoneNumberRef },
+                { $ref: buttonQuickReplyRef },
+              ],
+              discriminator: {
+                propertyName: 'type',
+                mapping: {
+                  URL: buttonURLRef,
+                  PHONE_NUMBER: buttonPhoneNumberRef,
+                  QUICK_REPLY: buttonQuickReplyRef,
                 },
               },
             },

--- a/spec/components/schemas/templates/components/carousel/index.ts
+++ b/spec/components/schemas/templates/components/carousel/index.ts
@@ -10,7 +10,7 @@ const carousel: SchemaObject = {
   description: `A collection of cards horizontally scrollable.
         <br><br>*Only applicable to [WhatsApp](#tag/WhatsApp) channel.*`,
   type: 'object',
-  required: ['type', 'cards'],
+  required: ['cards'],
   properties: {
     cards: {
       title: 'Cards',

--- a/spec/components/schemas/templates/components/carousel/index.ts
+++ b/spec/components/schemas/templates/components/carousel/index.ts
@@ -63,12 +63,12 @@ const carousel: SchemaObject = {
             minItems: 1,
             maxItems: 2,
             items: {
-                oneOf: [
-                  { $ref: buttonURLRef },
-                  { $ref: buttonPhoneNumberRef },
-                  { $ref: buttonQuickReplyRef },
-                ]
-            }
+              oneOf: [
+                { $ref: buttonURLRef },
+                { $ref: buttonPhoneNumberRef },
+                { $ref: buttonQuickReplyRef },
+              ],
+            },
           },
         },
       },

--- a/spec/components/schemas/templates/components/carousel/index.ts
+++ b/spec/components/schemas/templates/components/carousel/index.ts
@@ -1,24 +1,78 @@
 import { SchemaObject } from 'openapi3-ts';
 import { createComponentRef } from '../../../../../../utils/ref';
-import { ref as cardRef } from '../card';
+
+import { ref as buttonURLRef } from '../buttons/button-item-url';
+import { ref as buttonPhoneNumberRef } from '../buttons/button-item-phone-number';
+import { ref as buttonQuickReplyRef } from '../buttons/button-item-quick-reply';
 
 const carousel: SchemaObject = {
   title: 'Carousel',
-  description: '',
+  description: `A collection of cards horizontally scrollable.
+        <br><br>*Only applicable to [WhatsApp](#tag/WhatsApp) channel.*`,
   type: 'object',
-  required: [],
+  required: ['type', 'cards'],
   properties: {
     type: {
       title: 'Cards type',
-      description: 'The cards can beither fixed or unordered. An order for the unordered cards is selected on dispatch for that carousel template.',
+      description: 'The cards can beither fixed or unordered. An order for the unordered cards is defined upon dispatch of the template.',
       type: 'string',
       enum: ['CARD_FIXED','CARD_TEMPLATE'],
     },
     cards: {
-      allOf: [{
-        $ref: cardRef,
-      }],
-    }
+      title: 'Cards',
+      description: 'A boxed media that contains text, buttons and an image.',
+      type: 'array',
+      minItems: 2,
+      maxItems: 10,
+      items: {
+        type: 'object',
+        required: ['header', 'body', 'buttons'],
+        properties: {
+          header: {
+            title: 'Card header',
+            description: 'Where the card image will be placed',
+            required: ['type'],
+            properties: {
+              type: {
+                title: 'Type of header for the card',
+                type: 'string',
+                enum: ['MEDIA_IMAGE','MEDIA_VIDEO'],
+              },
+            },
+          },
+          body: {
+            title: 'Card body',
+            required: ['type', 'text'],
+            description: 'Where the card text will be inserted',
+            properties: {
+              type: {
+                title: 'Card body type',
+                type: 'string',
+                enum: ['TEXT_FIXED','TEXT_TEMPLATE'],
+              },
+              text: {
+                title: 'Card body text',
+                type: 'string',
+              },
+            },
+          },
+          buttons: {
+            title: 'Card buttons',
+            description: 'Where one or two buttons of type URL, Quick Reply or Phone Number shall be included',
+            type: 'array',
+            minItems: 1,
+            maxItems: 2,
+            items: {
+                oneOf: [
+                  { $ref: buttonURLRef },
+                  { $ref: buttonPhoneNumberRef },
+                  { $ref: buttonQuickReplyRef },
+                ]
+            }
+          },
+        },
+      },
+    },
   },
 };
 

--- a/spec/components/schemas/templates/components/carousel/index.ts
+++ b/spec/components/schemas/templates/components/carousel/index.ts
@@ -1,9 +1,9 @@
 import { SchemaObject } from 'openapi3-ts';
 import { createComponentRef } from '../../../../../../utils/ref';
 
-import { ref as buttonURLRef } from '../buttons/button-item-url';
-import { ref as buttonPhoneNumberRef } from '../buttons/button-item-phone-number';
-import { ref as buttonQuickReplyRef } from '../buttons/button-item-quick-reply';
+import { ref as actionsRef } from './buttons/actions';
+import { ref as quickRepliesRef } from './buttons/quick-replies';
+import { ref as mixedRef } from './buttons/mixed';
 
 const carousel: SchemaObject = {
   title: 'Carousel',
@@ -12,12 +12,6 @@ const carousel: SchemaObject = {
   type: 'object',
   required: ['type', 'cards'],
   properties: {
-    type: {
-      title: 'Cards type',
-      description: 'The cards can either have their position fixed or defined upon dispatch.',
-      type: 'string',
-      enum: ['CARD_FIXED','CARD_TEMPLATE'],
-    },
     cards: {
       title: 'Cards',
       description: 'A boxed media that contains text, buttons and an image.',
@@ -59,22 +53,21 @@ const carousel: SchemaObject = {
           buttons: {
             title: 'Card buttons',
             description: 'Buttons of type URL, Quick Reply and Phone Number',
-            type: 'array',
-            minItems: 1,
-            maxItems: 2,
-            items: {
-              oneOf: [
-                { $ref: buttonURLRef },
-                { $ref: buttonPhoneNumberRef },
-                { $ref: buttonQuickReplyRef },
-              ],
-              discriminator: {
-                propertyName: 'type',
-                mapping: {
-                  URL: buttonURLRef,
-                  PHONE_NUMBER: buttonPhoneNumberRef,
-                  QUICK_REPLY: buttonQuickReplyRef,
-                },
+            type: 'object',
+            oneOf: [{
+              $ref: actionsRef,
+            }, {
+              $ref: quickRepliesRef,
+            }, {
+              $ref: mixedRef,
+            }],
+            required: ['type'],
+            discriminator: {
+              propertyName: 'type',
+              mapping: {
+                ACTIONS: actionsRef,
+                QUICK_REPLIES: quickRepliesRef,
+                MIXED: mixedRef,
               },
             },
           },

--- a/spec/components/schemas/templates/components/carousel/index.ts
+++ b/spec/components/schemas/templates/components/carousel/index.ts
@@ -59,21 +59,30 @@ const carousel: SchemaObject = {
           buttons: {
             title: 'Card buttons',
             description: 'Where one or two buttons of type URL, Quick Reply or Phone Number shall be included',
-            type: 'array',
-            minItems: 1,
-            maxItems: 2,
-            items: {
-              oneOf: [
-                { $ref: buttonURLRef },
-                { $ref: buttonPhoneNumberRef },
-                { $ref: buttonQuickReplyRef },
-              ],
-              discriminator: {
-                propertyName: 'type',
-                mapping: {
-                  URL: buttonURLRef,
-                  PHONE_NUMBER: buttonPhoneNumberRef,
-                  QUICK_REPLY: buttonQuickReplyRef,
+            properties: {
+              type: {
+                type: 'string',
+                description: 'Button types',
+                example: 'QUICK_REPLIES',
+              },
+              items: {
+                type: 'array',
+                minItems: 1,
+                maxItems: 2,
+                items: {
+                  oneOf: [
+                    { $ref: buttonURLRef },
+                    { $ref: buttonPhoneNumberRef },
+                    { $ref: buttonQuickReplyRef },
+                  ],
+                  discriminator: {
+                    propertyName: 'type',
+                    mapping: {
+                      URL: buttonURLRef,
+                      PHONE_NUMBER: buttonPhoneNumberRef,
+                      QUICK_REPLY: buttonQuickReplyRef,
+                    },
+                  },
                 },
               },
             },

--- a/spec/components/schemas/templates/components/carousel/index.ts
+++ b/spec/components/schemas/templates/components/carousel/index.ts
@@ -68,6 +68,14 @@ const carousel: SchemaObject = {
                 { $ref: buttonPhoneNumberRef },
                 { $ref: buttonQuickReplyRef },
               ],
+              discriminator: {
+                propertyName: 'type',
+                mapping: {
+                  URL: buttonURLRef,
+                  PHONE_NUMBER: buttonPhoneNumberRef,
+                  QUICK_REPLY: buttonQuickReplyRef,
+                },
+              },
             },
           },
         },

--- a/spec/components/schemas/templates/components/whatsapp.ts
+++ b/spec/components/schemas/templates/components/whatsapp.ts
@@ -6,6 +6,7 @@ import { ref as bodyRef } from './body';
 import { ref as footerRef } from './footer';
 import { ref as buttonsRef } from './buttons';
 import { ref as otpRef } from './otp';
+import { ref as carouselRef } from './carousel';
 
 const whatsappComponents: SchemaObject = {
   title: 'Components',
@@ -26,6 +27,9 @@ const whatsappComponents: SchemaObject = {
     },
     otp: {
       $ref: otpRef,
+    },
+    carousel: {
+      $ref: carouselRef,
     },
   },
 };

--- a/spec/tags/templates.md
+++ b/spec/tags/templates.md
@@ -7,6 +7,8 @@ Templates have the following components:
 * Body
 * Footer
 * Buttons
+* OTP
+* Carousel
 
 The components object allows you to indicate the type of message and the message's parameters.
 

--- a/test/contract/cases/channels/whatsapp/send-template-with-carousel.json
+++ b/test/contract/cases/channels/whatsapp/send-template-with-carousel.json
@@ -1,0 +1,55 @@
+{
+  "name": "send template with carousel content",
+  "request": {
+    "method": "POST",
+    "path": "/channels/whatsapp/messages",
+    "query": {
+    },
+    "headers": {
+      "content-type": "application/json",
+      "x-api-token": "some-api-token"
+    },
+    "body": {
+      "from": "SENDER ID",
+      "to": "RECIPIENT ID",
+      "contents": [{
+        "type": "template",
+        "templateId": "some template id",
+        "fields": {
+          "cards": [{
+            "orderPosition": 0,
+            "imageUrl": "0"
+          }, {
+            "orderPosition": 1,
+            "imageUrl": "http"
+          }]
+        }
+      }]
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "content-type": "application/json"
+    },
+    "body": {
+      "id": "CREATED MESSAGE ID",
+      "direction": "OUT",
+      "from": "SENDER ID",
+      "to": "RECIPIENT ID",
+      "contents": [{
+        "type": "template",
+        "templateId": "some template id",
+        "fields": {
+          "cards": [{
+            "orderPosition": 0,
+            "imageUrl": "0"
+          }, {
+            "orderPosition": 1,
+            "imageUrl": "http"
+          }]
+        }
+      }]
+    }
+  }
+}

--- a/test/contract/cases/templates/whatsapp/create-with-carousel.json
+++ b/test/contract/cases/templates/whatsapp/create-with-carousel.json
@@ -31,9 +31,8 @@
                 "type": "TEXT_FIXED",
                 "text": "some text"
               },
-              "buttons": {
-                "type": "QUICK_REPLIES",
-                "items": [{
+              "buttons": [
+                {
                   "type": "QUICK_REPLY",
                   "text": "Some Button",
                   "payload": "quick-reply-payload"
@@ -41,8 +40,8 @@
                   "type": "URL",
                   "text": "Other Button",
                   "url": "https://example.com/endpoint"
-                }]
-              }
+                }
+              ]
             },
             {
               "header": {
@@ -52,14 +51,13 @@
                 "type": "TEXT_FIXED",
                 "text": "some other text"
               },
-              "buttons": {
-                "type": "ACTION",
-                "items": [{
+              "buttons": [
+                {
                   "type": "PHONE_NUMBER",
                   "text": "text",
                   "phoneNumber": "+5511991992993"
-                }]
-              }
+                }
+              ]
             }
           ]
         }
@@ -94,9 +92,8 @@
                 "type": "TEXT_FIXED",
                 "text": "some text"
               },
-              "buttons": {
-                "type": "QUICK_REPLIES",
-                "items": [{
+              "buttons": [
+                {
                   "type": "QUICK_REPLY",
                   "text": "Some Button",
                   "payload": "quick-reply-payload"
@@ -104,8 +101,8 @@
                   "type": "URL",
                   "text": "Other Button",
                   "url": "https://example.com/endpoint"
-                }]
-              }
+                }
+              ]
             },
             {
               "header": {
@@ -115,14 +112,13 @@
                 "type": "TEXT_FIXED",
                 "text": "some other text"
               },
-              "buttons": {
-                "type": "ACTION",
-                "items": [{
+              "buttons": [
+                {
                   "type": "PHONE_NUMBER",
                   "text": "text",
                   "phoneNumber": "+5511991992993"
-                }]
-              }
+                }
+              ]
             }
           ]
         }

--- a/test/contract/cases/templates/whatsapp/create-with-carousel.json
+++ b/test/contract/cases/templates/whatsapp/create-with-carousel.json
@@ -1,0 +1,133 @@
+{
+  "name": "create whatsapp template with carousel",
+  "request": {
+    "method": "POST",
+    "path": "/templates",
+    "query": {
+    },
+    "headers": {
+      "content-type": "application/json",
+      "x-api-token": "some-api-token"
+    },
+    "body": {
+      "name": "template name",
+      "locale": "pt_BR",
+      "channel": "WHATSAPP",
+      "senderId": "SENDER_ID",
+      "category": "MARKETING",
+      "components": {
+        "body": {
+          "type": "TEXT_FIXED",
+          "text": "some text"
+        },
+        "carousel": {
+          "type": "CARD_FIXED",
+          "cards": [
+            {
+              "header": {
+                "type": "MEDIA_IMAGE"
+              },
+              "body": {
+                "type": "TEXT_FIXED",
+                "text": "some text"
+              },
+              "buttons": {
+                "type": "QUICK_REPLIES",
+                "items": [{
+                  "type": "QUICK_REPLY",
+                  "text": "Some Button",
+                  "payload": "quick-reply-payload"
+                }, {
+                  "type": "URL",
+                  "text": "Other Button",
+                  "url": "https://example.com/endpoint"
+                }]
+              }
+            },
+            {
+              "header": {
+                "type": "MEDIA_IMAGE"
+              },
+              "body": {
+                "type": "TEXT_FIXED",
+                "text": "some other text"
+              },
+              "buttons": {
+                "type": "ACTION",
+                "items": [{
+                  "type": "PHONE_NUMBER",
+                  "text": "text",
+                  "phoneNumber": "+5511991992993"
+                }]
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "content-type": "application/json"
+    },
+    "body": {
+      "id": "UUID",
+      "name": "template name",
+      "locale": "pt_BR",
+      "channel": "WHATSAPP",
+      "senderId": "SENDER_ID",
+      "category": "MARKETING",
+      "components": {
+        "body": {
+          "type": "TEXT_FIXED",
+          "text": "some text"
+        },
+        "carousel": {
+          "type": "CARD_FIXED",
+          "cards": [
+            {
+              "header": {
+                "type": "MEDIA_IMAGE"
+              },
+              "body": {
+                "type": "TEXT_FIXED",
+                "text": "some text"
+              },
+              "buttons": {
+                "type": "QUICK_REPLIES",
+                "items": [{
+                  "type": "QUICK_REPLY",
+                  "text": "Some Button",
+                  "payload": "quick-reply-payload"
+                }, {
+                  "type": "URL",
+                  "text": "Other Button",
+                  "url": "https://example.com/endpoint"
+                }]
+              }
+            },
+            {
+              "header": {
+                "type": "MEDIA_IMAGE"
+              },
+              "body": {
+                "type": "TEXT_FIXED",
+                "text": "some other text"
+              },
+              "buttons": {
+                "type": "ACTION",
+                "items": [{
+                  "type": "PHONE_NUMBER",
+                  "text": "text",
+                  "phoneNumber": "+5511991992993"
+                }]
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+

--- a/test/contract/cases/templates/whatsapp/create-with-carousel.json
+++ b/test/contract/cases/templates/whatsapp/create-with-carousel.json
@@ -31,17 +31,20 @@
                 "type": "TEXT_FIXED",
                 "text": "some text"
               },
-              "buttons": [
-                {
-                  "type": "QUICK_REPLY",
-                  "text": "Some Button",
-                  "payload": "quick-reply-payload"
-                }, {
-                  "type": "URL",
-                  "text": "Other Button",
-                  "url": "https://example.com/endpoint"
-                }
-              ]
+              "buttons": {
+                "type": "MIXED",
+                "items": [
+                  {
+                    "type": "QUICK_REPLY",
+                    "text": "Some Button",
+                    "payload": "quick-reply-payload"
+                  }, {
+                    "type": "URL",
+                    "text": "Other Button",
+                    "url": "https://example.com/endpoint"
+                  }
+                ]
+              }
             },
             {
               "header": {
@@ -51,13 +54,16 @@
                 "type": "TEXT_FIXED",
                 "text": "some other text"
               },
-              "buttons": [
-                {
-                  "type": "PHONE_NUMBER",
-                  "text": "text",
-                  "phoneNumber": "+5511991992993"
-                }
-              ]
+              "buttons": {
+                "type": "ACTIONS",
+                "items": [
+                  {
+                    "type": "PHONE_NUMBER",
+                    "text": "text",
+                    "phoneNumber": "+5511991992993"
+                  }
+                ]
+              }
             }
           ]
         }
@@ -92,17 +98,20 @@
                 "type": "TEXT_FIXED",
                 "text": "some text"
               },
-              "buttons": [
-                {
-                  "type": "QUICK_REPLY",
-                  "text": "Some Button",
-                  "payload": "quick-reply-payload"
-                }, {
-                  "type": "URL",
-                  "text": "Other Button",
-                  "url": "https://example.com/endpoint"
-                }
-              ]
+              "buttons": {
+                "type": "MIXED",
+                "items": [
+                  {
+                    "type": "QUICK_REPLY",
+                    "text": "Some Button",
+                    "payload": "quick-reply-payload"
+                  }, {
+                    "type": "URL",
+                    "text": "Other Button",
+                    "url": "https://example.com/endpoint"
+                  }
+                ]
+              }
             },
             {
               "header": {
@@ -112,13 +121,16 @@
                 "type": "TEXT_FIXED",
                 "text": "some other text"
               },
-              "buttons": [
-                {
-                  "type": "PHONE_NUMBER",
-                  "text": "text",
-                  "phoneNumber": "+5511991992993"
-                }
-              ]
+              "buttons": {
+                "type": "ACTIONS",
+                "items": [
+                  {
+                    "type": "PHONE_NUMBER",
+                    "text": "text",
+                    "phoneNumber": "+5511991992993"
+                  }
+                ]
+              }
             }
           ]
         }


### PR DESCRIPTION
Adding Carousel templates to WhatsApp dispatches

Features:
- Allow `cards` attribute in `fields` attribute for Whatsapp template dispatches.
- Allow `carousel` attribute in `components` attribute for templates. Currently only for WhatsApp templates.

![Screenshot 2025-01-15 122342](https://github.com/user-attachments/assets/e51a5aa1-ee53-4fd4-95a4-0ee7b61d18cf)
![Screenshot 2025-01-15 125359](https://github.com/user-attachments/assets/d4f6159a-ab2c-4c6e-8811-8af067d7d5e5)

