### PR TITLE
[WHAT-4411] Add missing card variables

### DIFF
--- a/spec/components/schemas/content/template.ts
+++ b/spec/components/schemas/content/template.ts
@@ -68,6 +68,19 @@ const template: SchemaObject = {
                           description: 'URL of the image',
                         },
                       },
+                      additionalProperties: {
+                        description: 'Value provided to fill the variable named after the property name.',
+                        oneOf: [{
+                          type: 'string',
+                          example: 'Zenvia',
+                        }, {
+                          type: 'number',
+                          example: 1,
+                        }, {
+                          type: 'boolean',
+                          example: true,
+                        }],
+                      },
                     },
                     {
                       title: 'Cards with dynamic ordering and video as background',
@@ -82,27 +95,64 @@ const template: SchemaObject = {
                           description: 'URL of the video',
                         },
                       },
+                      additionalProperties: {
+                        description: 'Value provided to fill the variable named after the property name.',
+                        oneOf: [{
+                          type: 'string',
+                          example: 'Zenvia',
+                        }, {
+                          type: 'number',
+                          example: 1,
+                        }, {
+                          type: 'boolean',
+                          example: true,
+                        }],
+                      },
                     },
                     {
                       title: 'Cards with predefined order and image as background',
                       required: ['imageUrl'],
-                      additionalProperties: false,
                       properties: {
                         imageUrl: {
                           type: 'string',
                           description: 'URL of the image',
                         },
                       },
+                      additionalProperties: {
+                        description: 'Value provided to fill the variable named after the property name.',
+                        oneOf: [{
+                          type: 'string',
+                          example: 'Zenvia',
+                        }, {
+                          type: 'number',
+                          example: 1,
+                        }, {
+                          type: 'boolean',
+                          example: true,
+                        }],
+                      },
                     },
                     {
                       title: 'Cards with predefined order and video as background',
                       required: ['videoUrl'],
-                      additionalProperties: false,
                       properties: {
                         videoUrl: {
                           type: 'string',
                           description: 'URL of the video',
                         },
+                      },
+                      additionalProperties: {
+                        description: 'Value provided to fill the variable named after the property name.',
+                        oneOf: [{
+                          type: 'string',
+                          example: 'Zenvia',
+                        }, {
+                          type: 'number',
+                          example: 1,
+                        }, {
+                          type: 'boolean',
+                          example: true,
+                        }],
                       },
                     },
                   ],


### PR DESCRIPTION
Adição das variáveis genéricas que podem ser enviadas para cada card:

![Captura de tela 2025-05-30 123329](https://github.com/user-attachments/assets/ac265c56-a4ab-4fcc-83e6-bf8407fc6855)

![Captura de tela 2025-05-30 123355](https://github.com/user-attachments/assets/f46e0bff-de0f-46cd-9f77-19a0db2b15a3)

![Captura de tela 2025-05-30 123413](https://github.com/user-attachments/assets/fc047efa-9f34-49bf-b573-2800c638d56d)

![Captura de tela 2025-05-30 123451](https://github.com/user-attachments/assets/d09c5931-5916-424b-824e-426b9d3c9cd5)
