### PR TITLE
Fixing orderDetailsParameter types

### DIFF
--- a/spec/components/schemas/content/whatsapp/order-details-template.ts
+++ b/spec/components/schemas/content/whatsapp/order-details-template.ts
@@ -31,7 +31,7 @@ const orderDetailsTemplate: SchemaObject = {
       },
       type: {
         type: 'string',
-        enum: ['digital-goods', 'physical-goods'],
+        enum: ['digital_goods', 'physical_goods'],
         description: 'The type of the order item.',
       },
       paymentSettings: {


### PR DESCRIPTION
Small fix. Inside API, the `orderDetailsParameter.type` should be qual to `[digital_goods, physical_goods]`  
while the message we send to the provider should be `[digital-goods, physical-goods]`