### PR TITLE
[WHAT-4476] Add unsupported type to webhooks section

### DIFF
--- a/spec/components/schemas/content/whatsapp/mt.ts
+++ b/spec/components/schemas/content/whatsapp/mt.ts
@@ -11,6 +11,7 @@ import { ref as productRef } from './product';
 import { ref as productListRef } from './product-list';
 import { ref as orderDetailsRef } from './order-details';
 import { ref as orderStatusRef } from './order-status';
+import { ref as unsupportedRef } from './unsupported';
 
 const mtContent: SchemaObject = {
   title: 'WhatsApp',
@@ -38,6 +39,8 @@ const mtContent: SchemaObject = {
   }, {
     $ref: orderStatusRef,
     'x-unpublished': true,
+  }, {
+    $ref: unsupportedRef,
   }],
   discriminator: {
     propertyName: 'type',
@@ -53,6 +56,7 @@ const mtContent: SchemaObject = {
       product_list: productListRef,
       order_details: orderDetailsRef,
       order_status: orderStatusRef,
+      unsupported: unsupportedRef,
     },
   },
 };

--- a/spec/components/schemas/content/whatsapp/unsupported.ts
+++ b/spec/components/schemas/content/whatsapp/unsupported.ts
@@ -1,0 +1,23 @@
+import { SchemaObject } from 'openapi3-ts';
+import { ref as baseRef } from '../base';
+import { createComponentRef } from '../../../../../utils/ref';
+
+const unsupported: SchemaObject = {
+  type: 'object',
+  allOf: [{
+    $ref: baseRef,
+  }, {
+    type: 'object',
+    properties: {
+      type: {
+        type: 'string',
+        example: 'unsupported',
+        description: 'Refers to a type of communication that is not supported by Meta.',
+      },
+    },
+    required: ['type'],
+  }],
+};
+
+export const ref = createComponentRef(__filename);
+export default unsupported;


### PR DESCRIPTION
Adição do novo tipo de webhook, para mensagens de whatsapp não suportadas

<img width="973" alt="unsupported" src="https://github.com/user-attachments/assets/a208513f-8ceb-486d-890a-c8f73e470e28" />
