### PR TITLE
Feature/plantech 2191 - [BUG] Ajuste doc RCS - templates

### DIFF
--- a/spec/components/schemas/content/template.ts
+++ b/spec/components/schemas/content/template.ts
@@ -2,7 +2,7 @@ import { SchemaObject } from 'openapi3-ts';
 import { ref as baseRef } from './base';
 import { createComponentRef } from '../../../../utils/ref';
 import { ref as productSections } from './whatsapp/product-sections';
-import {ref as orderDetailsTemplate} from './whatsapp/order-details-template';
+import { ref as orderDetailsTemplate } from './whatsapp/order-details-template';
 
 const template: SchemaObject = {
   type: 'object',
@@ -32,8 +32,8 @@ const template: SchemaObject = {
         },
         oneOf: [
           {
-            title: 'Cards',
-            required: ['cards'],
+            title: 'Default',
+            type: 'object',
             additionalProperties: {
               description: 'Value provided to fill the variable named after the property name.',
               oneOf: [{
@@ -47,6 +47,11 @@ const template: SchemaObject = {
                 example: true,
               }],
             },
+          },
+          {
+            title: 'Cards',
+            type: 'object',
+            required: ['cards'],
             properties: {
               cards: {
                 type: 'array',
@@ -166,6 +171,8 @@ const template: SchemaObject = {
           },
           {
             title: 'Product Sections',
+            required: ['sections'],
+            type: 'object',
             additionalProperties: {
               description: 'Value provided to fill the variable named after the property name.',
               oneOf: [{

--- a/spec/components/schemas/content/template.ts
+++ b/spec/components/schemas/content/template.ts
@@ -173,6 +173,9 @@ const template: SchemaObject = {
             title: 'Product Sections',
             required: ['sections'],
             type: 'object',
+            properties: {
+              sections: { $ref: productSections },
+            },
             additionalProperties: {
               description: 'Value provided to fill the variable named after the property name.',
               oneOf: [{
@@ -185,9 +188,6 @@ const template: SchemaObject = {
                 type: 'boolean',
                 example: true,
               }],
-            },
-            properties: {
-              sections: { $ref: productSections },
             },
           },
         ],

--- a/spec/components/schemas/content/whatsapp/product-sections.ts
+++ b/spec/components/schemas/content/whatsapp/product-sections.ts
@@ -5,8 +5,10 @@ const productSections: SchemaObject = {
   type: 'array',
   title: 'Product Sections',
   description: 'The available fields to be used in a product list. Only applicable to [WhatsApp](#tag/WhatsApp) channel.',
+  minItems: 1,
   items: {
     type: 'object',
+    required: ['title', 'productItems'],
     properties: {
       title: {
         type: 'string',
@@ -17,6 +19,7 @@ const productSections: SchemaObject = {
         description: 'A list of products.',
         items: {
           type: 'object',
+          required: ['productId'],
           properties: {
             productId: {
               type: 'string',


### PR DESCRIPTION
Na documentação de RCS Templates existe um trecho ligado a CARDs que só existe em whatsaap. 

Comportamento esperado:
Como alinhado com o @Davi das Neves Machado , esse trecho de CARDs deve ser retirado mantendo apenas o property name. 
