### PR TITLE
Ajuste da descrição de valores números nas APIs de Parceiros (Lotes)

### DIFF
--- a/spec/tags/invoice-batches.md
+++ b/spec/tags/invoice-batches.md
@@ -86,13 +86,13 @@ The predefined order must be:
   - **Required**: `true`
   - **Type**: `string or number`
     - Maintain decimal precision, do not round
-  - **Max Size**: `30` characters
-  - **Format**:
-    - Must only accept positive numbers;
-    - Numbers should not have a thousand separator;
-    - Must accept integers and decimals with `,` as a separator;
-    - Must not accept `.` as a decimal separator;
-    - Accepts a maximum of two decimal places;
+    - **Max Size**: `22` characters
+    - **Format**:
+      - Must only accept positive numbers;
+      - Numbers should not have a thousand separator;
+      - Must accept integers and decimals with `,` as a separator;
+      - Must not accept `.` as a decimal separator;
+      - Must accept up to 19 integer digits and a maximum of two decimal places;
     - **Example of valid formats**: `15236,15` | `458`
   - **Precision**: `19,2` in case of number.
 
@@ -120,13 +120,13 @@ The predefined order must be:
     - `quantity` - Item quantity
       - **Required**: `true`
       - **Type**: `string or number`
-      - **Max Size**: `30` characters
+      - **Max Size**: `22` characters
       - **Format**:
         - Must only accept positive numbers;
         - Numbers should not have a thousand separator;
         - Must accept integers and decimals with `,` as a separator;
         - Must not accept `.` as a decimal separator;
-        - Accepts a maximum of two decimal places;
+        - Must accept up to 19 integer digits and a maximum of two decimal places;
         - **Example of valid formats**: `15236,15` | `458`
     - **`measurementUnit`**: Item unit of measurement
       - **Required**: `true`
@@ -137,18 +137,27 @@ The predefined order must be:
       - **Required**: `true`
       - **Type**: `string or number`
         - Maintain decimal precision, do not round
-      - **Max Size**: `30` characters
+      - **Max Size**: `22` characters
       - **Format**:
         - Must only accept positive numbers;
         - Numbers should not have a thousand separator;
         - Must accept integers and decimals with `,` as a separator;
         - Must not accept `.` as a decimal separator;
-        - Accepts a maximum of two decimal places;
+        - Must accept up to 19 integer digits and a maximum of two decimal places;
         - **Example of valid formats**: `15236,15` | `458`
       - **Precision**: `19,2` in case of number.
     - `totalValue` - Total value of the item
       - **Required**: `false`
       - **Type**: `string | string[] / number | number[]`
+      - **Max Size**: `22` characters
+      - **Format**:
+        - Must only accept positive numbers;
+        - Numbers should not have a thousand separator;
+        - Must accept integers and decimals with `,` as a separator;
+        - Must not accept `.` as a decimal separator;
+        - Must accept up to 19 integer digits and a maximum of two decimal places;
+        - **Example of valid formats**: `15236,15` | `458`
+      - **Precision**: `19,2` in case of number.
     - `fiscalOperationCode` - Fiscal operation code
       - **Required**: `false`
       - **Type**: `string`

--- a/spec/tags/order-batches.md
+++ b/spec/tags/order-batches.md
@@ -52,13 +52,14 @@ The predefined order must be:
 - **`totalAmount`**: Total amount of the order
   - **Required**: `true`
   - **Type**: `string` || `number`
-  - **Max Size**: `30`
+  - **Max Size**: `22` characters
   - **Format**:
-    - Must accept only positive numbers;
-    - Numbers should not have thousands separators;
-    - Must accept integers and decimals with `,` (comma) separator;
-    - Must not accept decimal separator of `.`;
-    - Example of valid formats: `15236,15` | `458`
+    - Must only accept positive numbers;
+    - Numbers should not have a thousand separator;
+    - Must accept integers and decimals with `,` as a separator;
+    - Must not accept `.` as a decimal separator;
+    - Must accept up to 19 integer digits and a maximum of two decimal places;
+    - **Example of valid formats**: `15236,15` | `458`
   - **Precision**: `19,2` in case of number.
 
 - **`legalCode`**: Legal code (e.g., CNPJ, CPF)
@@ -141,9 +142,15 @@ The predefined order must be:
     - **`quantity`**: Item quantity
       - **Required**: `true`
       - **Type**: `string` || `number`
-      - **Format**: double
-      - Must accept only integers or decimals, without thousands separators and with comma (`,`) as decimal separator.
-      - **Max Size**: `30`
+      - **Max Size**: `22` characters
+      - **Format**:
+        - Must only accept positive numbers;
+        - Numbers should not have a thousand separator;
+        - Must accept integers and decimals with `,` as a separator;
+        - Must not accept `.` as a decimal separator;
+        - Must accept up to 19 integer digits and a maximum of two decimal places;
+        - **Example of valid formats**: `15236,15` | `458`
+      - **Precision**: `19,2` in case of number.
     - **`measurementUnit`**: Item unit of measurement
       - **Required**: `true`
       - **Type**: `string`
@@ -153,13 +160,13 @@ The predefined order must be:
       - **Required**: `true`
       - **Type**: `string or number`
         - Maintain decimal precision, do not round
-      - **Max Size**: `30` characters
+      - **Max Size**: `22` characters
       - **Format**:
         - Must only accept positive numbers;
         - Numbers should not have a thousand separator;
         - Must accept integers and decimals with `,` as a separator;
         - Must not accept `.` as a decimal separator;
-        - Accepts a maximum of two decimal places;
+        - Must accept up to 19 integer digits and a maximum of two decimal places;
         - **Example of valid formats**: `15236,15` | `458`
       - **Precision**: `19,2` in case of number.
     - **`currency`**: Currency

--- a/spec/tags/product-batches.md
+++ b/spec/tags/product-batches.md
@@ -68,12 +68,13 @@ The predefined order must be:
   - **Required**: `true`
   - **Type**: `string` || `number`
   - **Max Size**: `30`
+  - **Max Size**: `22` characters
   - **Format**:
-    - Must accept only positive numbers;
-    - Numbers should not have thousands separators;
-    - Must accept integers and decimals with `,` (comma) separator;
-    - Must not accept decimal separator of `.`;
-    - Accepts a maximum of two decimal places;
+    - Must only accept positive numbers;
+    - Numbers should not have a thousand separator;
+    - Must accept integers and decimals with `,` as a separator;
+    - Must not accept `.` as a decimal separator;
+    - Must accept up to 19 integer digits and a maximum of two decimal places;
     - **Example of valid formats**: `15236,15` | `458`
   - **Precision**: `19,2` in case of number.
 


### PR DESCRIPTION
O envio de valores numéricos pelas apis deve ser em formato precision(9,2), ou seja, números inteiros até 9 dígitos e duas casas decimais;

Dessa forma, foi necessário alterar as funções e testes relacionadas ao tratamento desse tipo de dado, para que ficasse claro o tamanho do número até 19 inteiros e até dois números decimais, totalizando 22 caracteres.

Os campos alterados foram:

* `quantity`
* `totalAmount`
* `priceUnity`
* `totalValue`

APIS Impactadas : INVOICE, ORDER e PRODUCTS

API de contato não tem esse tipo de validação