### PR TITLE
Alterar critérios de filtragem

### DIFF
--- a/spec/components/schemas/events/message-event.ts
+++ b/spec/components/schemas/events/message-event.ts
@@ -29,9 +29,7 @@ const messageEvent: SchemaObject = {
 
 * **IN**: Received messages.
 * **OUT**: Sent messages.
-* **ALL**: Filters messages from both directions.
-
-> **Note:** The **OUT** direction is under construction.`,
+* **ALL**: Filters messages from both directions.`,
         type: 'string',
         enum: [
           'IN',

--- a/spec/components/schemas/events/message-event.ts
+++ b/spec/components/schemas/events/message-event.ts
@@ -25,12 +25,18 @@ const messageEvent: SchemaObject = {
       },
       direction: {
         title: 'Message Direction',
-        description: `Indicates whether the message is received from a channel (IN) or sent to a channel (OUT)
+        description: `Indicates whether the message is received from a channel (**IN**), sent to a channel (**OUT**), or both (**ALL**).
+
+* **IN**: Received messages.
+* **OUT**: Sent messages.
+* **ALL**: Filters messages from both directions.
+
 > **Note:** The **OUT** direction is under construction.`,
         type: 'string',
         enum: [
           'IN',
           'OUT',
+          'ALL',
         ],
       },
       message: {

--- a/spec/components/schemas/events/message-status-event.ts
+++ b/spec/components/schemas/events/message-status-event.ts
@@ -23,6 +23,22 @@ const messageEvent: SchemaObject = {
         title: 'Message Channel',
         type: 'string',
       },
+      direction: {
+        title: 'Message Status Direction',
+        description: `Indicates whether the message status is received from a channel (**IN**), sent to a channel (**OUT**), or both (**ALL**).
+
+* **IN**: Received messages.
+* **OUT**: Sent messages.
+* **ALL**: Filters messages from both directions.
+
+> **Note:** The **OUT** direction is under construction.`,
+        type: 'string',
+        enum: [
+          'IN',
+          'OUT',
+          'ALL',
+        ],
+      },
       messageId: {
         title: 'Message ID',
         description: 'ID of the message whose status is being delivered',

--- a/spec/components/schemas/events/message-status-event.ts
+++ b/spec/components/schemas/events/message-status-event.ts
@@ -29,9 +29,7 @@ const messageEvent: SchemaObject = {
 
 * **IN**: Received messages.
 * **OUT**: Sent messages.
-* **ALL**: Filters messages from both directions.
-
-> **Note:** The **OUT** direction is under construction.`,
+* **ALL**: Filters messages from both directions.`,
         type: 'string',
         enum: [
           'IN',


### PR DESCRIPTION
Para permitir o envio dos status de ligações recebidas e realizadas com a mesma configuração de webhook, precisamos ter a opção de configurar o filtro com ambos os sentidos.

Nos critérios do evento de mensagem, adicionar novo filtro:

**ALL**

Nos critérios do evento de status de mensagem, adicionar filtro por direção da mensagem:

**IN, OUT, ALL**